### PR TITLE
feat: add light theme variables

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,38 @@
     --sidebar-border-light: 240 5.9% 90%;
     --sidebar-ring-light: 24 100% 53%;
   }
+
+  .light {
+    --background: var(--background-light);
+    --foreground: var(--foreground-light);
+    --card: var(--card-light);
+    --card-foreground: var(--card-foreground-light);
+    --popover: var(--popover-light);
+    --popover-foreground: var(--popover-foreground-light);
+    --primary: var(--primary-light);
+    --primary-foreground: var(--primary-foreground-light);
+    --secondary: var(--secondary-light);
+    --secondary-foreground: var(--secondary-foreground-light);
+    --muted: var(--muted-light);
+    --muted-foreground: var(--muted-foreground-light);
+    --accent: var(--accent-light);
+    --accent-foreground: var(--accent-foreground-light);
+    --destructive: var(--destructive-light);
+    --destructive-foreground: var(--destructive-foreground-light);
+    --border: var(--border-light);
+    --input: var(--input-light);
+    --ring: var(--ring-light);
+
+    /* Sidebar variables */
+    --sidebar: var(--sidebar-light);
+    --sidebar-foreground: var(--sidebar-foreground-light);
+    --sidebar-primary: var(--sidebar-primary-light);
+    --sidebar-primary-foreground: var(--sidebar-primary-foreground-light);
+    --sidebar-accent: var(--sidebar-accent-light);
+    --sidebar-accent-foreground: var(--sidebar-accent-foreground-light);
+    --sidebar-border: var(--sidebar-border-light);
+    --sidebar-ring: var(--sidebar-ring-light);
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- map CSS tokens to light-mode counterparts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6890ed192a548326b7562b04ef99b166