### PR TITLE
Ensure BigQuery edge function returns explicit 200 status

### DIFF
--- a/supabase/functions/bigquery-aso-data/index.ts
+++ b/supabase/functions/bigquery-aso-data/index.ts
@@ -602,7 +602,11 @@ serve(async (req) => {
           })
         }
       }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      {
+        // ✅ Required to ensure Supabase Edge returns valid response
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
     );
 
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- explicitly set `status: 200` in BigQuery ASO data edge function

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any, etc.)

------
https://chatgpt.com/codex/tasks/task_e_6894b99e847083268479dee48cd5f617