### PR TITLE
feat: add first impression tab

### DIFF
--- a/src/components/AsoAiHub/CreativeAnalysis/CreativeAnalysisResults.tsx
+++ b/src/components/AsoAiHub/CreativeAnalysis/CreativeAnalysisResults.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { CreativeAnalysisWithAI, ScreenshotAnalysis } from '@/services/creative-analysis.service';
-import { ColorPaletteDisplay } from './ColorPaletteDisplay';
-import { MessageAnalysisPanel } from './MessageAnalysisPanel';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { CreativeAnalysisWithAI } from '@/services/creative-analysis.service';
 import { ScreenshotAnalysisCard } from './ScreenshotAnalysisCard';
 import { PatternRecognitionSummary } from './PatternRecognitionSummary';
+import { FirstImpressionPanel } from './FirstImpressionPanel';
 
 interface CreativeAnalysisResultsProps {
   analysis: CreativeAnalysisWithAI;
@@ -32,30 +32,41 @@ export const CreativeAnalysisResults: React.FC<CreativeAnalysisResultsProps> = (
   }
 
   return (
-    <div className="space-y-6">
-      {/* Pattern Recognition Summary */}
-      {analysis.patterns && (
-        <PatternRecognitionSummary 
-          patterns={analysis.patterns} 
-          keyword={keyword}
-          analysisCount={analysis.individual.length}
-        />
-      )}
-
-      {/* Individual Screenshot Analysis */}
-      <div className="space-y-6">
-        <h3 className="text-xl font-semibold text-zinc-100">
-          Screenshot Analysis Results
-        </h3>
-        
-        {analysis.individual.map((screenshot, index) => (
-          <ScreenshotAnalysisCard 
-            key={`${screenshot.appId}-${index}`}
-            analysis={screenshot}
-            index={index}
+    <Tabs defaultValue="analysis" className="w-full">
+      <TabsList className="grid w-full grid-cols-2 bg-zinc-800">
+        <TabsTrigger value="analysis" className="data-[state=active]:bg-zinc-700">
+          Analysis
+        </TabsTrigger>
+        <TabsTrigger value="first" className="data-[state=active]:bg-zinc-700">
+          First Impression
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="analysis" className="space-y-6 mt-6">
+        {analysis.patterns && (
+          <PatternRecognitionSummary
+            patterns={analysis.patterns}
+            keyword={keyword}
+            analysisCount={analysis.individual.length}
           />
-        ))}
-      </div>
-    </div>
+        )}
+
+        <div className="space-y-6">
+          <h3 className="text-xl font-semibold text-zinc-100">
+            Screenshot Analysis Results
+          </h3>
+
+          {analysis.individual.map((screenshot, index) => (
+            <ScreenshotAnalysisCard
+              key={`${screenshot.appId}-${index}`}
+              analysis={screenshot}
+              index={index}
+            />
+          ))}
+        </div>
+      </TabsContent>
+      <TabsContent value="first" className="mt-6">
+        <FirstImpressionPanel analysis={analysis} />
+      </TabsContent>
+    </Tabs>
   );
 };

--- a/src/components/AsoAiHub/CreativeAnalysis/FirstImpressionPanel.tsx
+++ b/src/components/AsoAiHub/CreativeAnalysis/FirstImpressionPanel.tsx
@@ -1,0 +1,71 @@
+import React, { useMemo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CreativeAnalysisWithAI } from '@/services/creative-analysis.service';
+
+interface FirstImpressionPanelProps {
+  analysis: CreativeAnalysisWithAI;
+}
+
+export const FirstImpressionPanel: React.FC<FirstImpressionPanelProps> = ({ analysis }) => {
+  const firstThree = analysis.individual.slice(0, 3);
+
+  const coherence = useMemo(() => {
+    if (firstThree.length === 0) return 0;
+
+    const keywordSets = firstThree.map(s => new Set((s.messageAnalysis.keywords || []).map(k => k.toLowerCase())));
+    const union = new Set<string>();
+    keywordSets.forEach(set => set.forEach(k => union.add(k)));
+
+    const intersection = keywordSets.reduce<Set<string> | null>((acc, set) => {
+      if (acc === null) return new Set(set);
+      return new Set(Array.from(acc).filter(k => set.has(k)));
+    }, null);
+
+    return union.size > 0 && intersection ? Math.round((intersection.size / union.size) * 100) : 0;
+  }, [firstThree]);
+
+  if (firstThree.length === 0) {
+    return <p className="text-zinc-400">No screenshots available for first impression.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {firstThree.map((shot, idx) => (
+          <div key={idx} className="space-y-2">
+            <img
+              src={shot.screenshotUrl}
+              alt={`Screenshot ${idx + 1}`}
+              className="w-full rounded-lg border border-zinc-800"
+            />
+            <p className="text-sm text-zinc-300">{shot.messageAnalysis.primaryMessage}</p>
+          </div>
+        ))}
+      </div>
+
+      <Card className="bg-zinc-900 border-zinc-800">
+        <CardHeader>
+          <CardTitle className="text-foreground">Messaging Flow</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ol className="list-decimal list-inside space-y-1 text-zinc-200">
+            {firstThree.map((shot, idx) => (
+              <li key={idx}>{shot.messageAnalysis.primaryMessage}</li>
+            ))}
+          </ol>
+        </CardContent>
+      </Card>
+
+      <Card className="bg-zinc-900 border-zinc-800">
+        <CardHeader>
+          <CardTitle className="text-foreground">Coherence Score</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold text-zinc-100">{coherence}%</p>
+          <p className="text-sm text-zinc-400">Keyword overlap across first three screenshots</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+

--- a/src/components/AsoAiHub/CreativeAnalysis/index.ts
+++ b/src/components/AsoAiHub/CreativeAnalysis/index.ts
@@ -6,3 +6,4 @@ export { ScreenshotAnalysisCard } from './ScreenshotAnalysisCard';
 export { ColorPaletteDisplay } from './ColorPaletteDisplay';
 export { MessageAnalysisPanel } from './MessageAnalysisPanel';
 export { PatternRecognitionSummary } from './PatternRecognitionSummary';
+export { FirstImpressionPanel } from './FirstImpressionPanel';


### PR DESCRIPTION
## Summary
- add First Impression panel to compare first three screenshots and calculate keyword-based coherence
- wire new panel into Creative Analysis results with tab navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 554 problems, see log)*
- `npx eslint src/components/AsoAiHub/CreativeAnalysis/FirstImpressionPanel.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6895eabb7b3083269a99c191ddafcbc6