### PR TITLE
chore: add BigQuery transform debug logs

### DIFF
--- a/src/hooks/useBigQueryData.ts
+++ b/src/hooks/useBigQueryData.ts
@@ -291,6 +291,17 @@ function transformBigQueryToAsoData(
   trafficSources: string[],
   meta: BigQueryMeta
 ): AsoData {
+  console.log('🔍 [Transform] Input data analysis:', {
+    totalDataPoints: bigQueryData.length,
+    uniqueTrafficSources: [...new Set(bigQueryData.map(item => item.traffic_source))],
+    sampleDataPoints: bigQueryData.slice(0, 3).map(item => ({
+      date: item.date,
+      traffic_source: item.traffic_source,
+      impressions: item.impressions,
+      downloads: item.downloads
+    }))
+  });
+
   const dateGroups = bigQueryData.reduce((acc, item) => {
     const date = item.date;
     if (!acc[date]) {
@@ -360,14 +371,24 @@ function transformBigQueryToAsoData(
     trafficSourceGroups[source].delta = generateMockDelta();
   });
 
+  console.log('🔍 [Transform] Traffic source groups:', {
+    allGroups: Object.keys(trafficSourceGroups),
+    groupValues: Object.entries(trafficSourceGroups).map(([source, data]) => ({
+      source,
+      value: data.value
+    }))
+  });
+
   const availableTrafficSources = meta.availableTrafficSources || [];
   const sourcesToShow = availableTrafficSources.length > 0 ? availableTrafficSources : trafficSources;
-  
+
   const trafficSourceData: TrafficSource[] = sourcesToShow.map(source => ({
     name: source,
     value: trafficSourceGroups[source]?.value || 0,
     delta: trafficSourceGroups[source]?.delta || 0
   }));
+
+  console.log('🔍 [Transform] Final traffic source data:', trafficSourceData);
 
   debugLog.verbose('Transform complete', {
     totalItems: bigQueryData.length,


### PR DESCRIPTION
## Summary
- add console debug logs to inspect BigQuery transform inputs and outputs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any types and forbidden require imports)*

------
https://chatgpt.com/codex/tasks/task_e_6899e179c4488326879dd443df5a619d