### PR TITLE
feat: add dual CVR metrics

### DIFF
--- a/src/hooks/useBigQueryData.ts
+++ b/src/hooks/useBigQueryData.ts
@@ -366,13 +366,29 @@ function transformBigQueryToAsoData(
     impressions: { value: totals.impressions, delta: generateMockDelta() },
     downloads: { value: totals.downloads, delta: generateMockDelta() },
     product_page_views: { value: totals.product_page_views, delta: generateMockDelta() },
-    cvr: { 
-      value: totals.product_page_views > 0 ? 
-        (totals.downloads / totals.product_page_views) * 100 : 
-        (totals.impressions > 0 ? (totals.downloads / totals.impressions) * 100 : 0), 
-      delta: generateMockDelta() 
+    product_page_cvr: {
+      value: totals.product_page_views > 0 ?
+        (totals.downloads / totals.product_page_views) * 100 : 0,
+      delta: generateMockDelta()
+    },
+    impressions_cvr: {
+      value: totals.impressions > 0 ?
+        (totals.downloads / totals.impressions) * 100 : 0,
+      delta: generateMockDelta()
     }
   };
+
+  console.log('📊 [Transform] Dual CVR calculations:', {
+    totalImpressions: totals.impressions,
+    totalDownloads: totals.downloads,
+    totalPageViews: totals.product_page_views,
+    productPageCVR: summary.product_page_cvr.value,
+    impressionsCVR: summary.impressions_cvr.value,
+    expectedProductPageCVR: totals.product_page_views > 0 ?
+      ((totals.downloads / totals.product_page_views) * 100).toFixed(3) : '0.000',
+    expectedImpressionsCVR: totals.impressions > 0 ?
+      ((totals.downloads / totals.impressions) * 100).toFixed(3) : '0.000'
+  });
 
   const trafficSourceGroups = bigQueryData.reduce((acc, item) => {
     const source = item.traffic_source || 'Unknown';

--- a/src/hooks/useMockAsoData.ts
+++ b/src/hooks/useMockAsoData.ts
@@ -15,7 +15,8 @@ export interface AsoMetrics {
   impressions: MetricSummary;
   downloads: MetricSummary;
   product_page_views: MetricSummary; // Renamed from 'pageViews' to match App Store Connect
-  cvr: MetricSummary;
+  product_page_cvr: MetricSummary;
+  impressions_cvr: MetricSummary;
 }
 
 export interface TrafficSource {
@@ -75,8 +76,12 @@ export const useMockAsoData = (
           impressions: generateMetric(),
           downloads: generateMetric(),
           product_page_views: generateMetric(), // Renamed from 'pageViews'
-          cvr: { 
-            value: parseFloat((Math.random() * 10).toFixed(2)), // 0 to 10%
+          product_page_cvr: {
+            value: parseFloat((Math.random() * 100).toFixed(2)), // 0 to 100%
+            delta: parseFloat((Math.random() * 40 - 20).toFixed(1)) // -20% to +20%
+          },
+          impressions_cvr: {
+            value: parseFloat((Math.random() * 100).toFixed(2)), // 0 to 100%
             delta: parseFloat((Math.random() * 40 - 20).toFixed(1)) // -20% to +20%
           }
         };


### PR DESCRIPTION
## Summary
- split single CVR metric into product_page_cvr and impressions_cvr
- compute and log dual CVRs in BigQuery transform
- update mock data generator for new CVR metrics
