### PR TITLE
refactor: migrate to dual CVR metrics

### DIFF
--- a/cvr-reference-inventory.ts
+++ b/cvr-reference-inventory.ts
@@ -1,0 +1,69 @@
+interface CVRReferenceInventory {
+  file: string;
+  lineNumber: number;
+  currentCode: string;
+  category: 'component' | 'hook' | 'util' | 'test' | 'type' | 'context';
+  updateStrategy: 'replace-with-product-page' | 'replace-with-impressions' | 'replace-with-both' | 'remove';
+  priority: 'high' | 'medium' | 'low';
+}
+
+const referenceInventory: CVRReferenceInventory[] = [
+  {
+    file: 'src/hooks/useAsoInsights.ts',
+    lineNumber: 47,
+    currentCode: 'cvrValue: data?.summary?.cvr?.value',
+    category: 'hook',
+    updateStrategy: 'replace-with-both',
+    priority: 'high'
+  },
+  {
+    file: 'src/hooks/useComparisonData.ts',
+    lineNumber: 23,
+    currentCode: 'cvr: number;',
+    category: 'type',
+    updateStrategy: 'replace-with-both',
+    priority: 'high'
+  },
+  {
+    file: 'src/pages/overview.tsx',
+    lineNumber: 157,
+    currentCode: '(data.summary.cvr ? data.summary.cvr.value : 0).toFixed(2)%',
+    category: 'component',
+    updateStrategy: 'replace-with-both',
+    priority: 'high'
+  },
+  {
+    file: 'src/pages/conversion-analysis.tsx',
+    lineNumber: 73,
+    currentCode: 'value={data.summary.cvr.value}',
+    category: 'component',
+    updateStrategy: 'replace-with-both',
+    priority: 'high'
+  },
+  {
+    file: 'src/utils/dateCalculations.ts',
+    lineNumber: 52,
+    currentCode: 'cvr: calculatePercentageChange(',
+    category: 'util',
+    updateStrategy: 'replace-with-both',
+    priority: 'high'
+  },
+  {
+    file: 'src/hooks/useComparisonData.test.tsx',
+    lineNumber: 29,
+    currentCode: 'cvr: { value: 50, delta: 3 }',
+    category: 'test',
+    updateStrategy: 'replace-with-both',
+    priority: 'medium'
+  },
+  {
+    file: 'src/pages/conversion-analysis.test.tsx',
+    lineNumber: 57,
+    currentCode: 'cvr: { value: 5.2, delta: 0.8 }',
+    category: 'test',
+    updateStrategy: 'replace-with-both',
+    priority: 'medium'
+  }
+];
+
+export default referenceInventory;

--- a/src/hooks/useAsoInsights.ts
+++ b/src/hooks/useAsoInsights.ts
@@ -44,8 +44,10 @@ export const useAsoInsights = (config: Partial<InsightGenerationConfig> = {}) =>
     usingDashboardData: !!config.dashboardData,
     hasData: !!data,
     dataSource: config.dashboardData ? 'dashboard-direct' : 'context',
-    cvrValue: data?.summary?.cvr?.value,
-    cvrDelta: data?.summary?.cvr?.delta,
+    productPageCvrValue: data?.summary?.product_page_cvr?.value,
+    productPageCvrDelta: data?.summary?.product_page_cvr?.delta,
+    impressionsCvrValue: data?.summary?.impressions_cvr?.value,
+    impressionsCvrDelta: data?.summary?.impressions_cvr?.delta,
     timestamp: new Date().toISOString()
   });
   
@@ -139,8 +141,10 @@ export const useAsoInsights = (config: Partial<InsightGenerationConfig> = {}) =>
         timestamp: new Date().toISOString(),
         // Add debugging info
         debug: {
-          cvrValue: data.summary?.cvr?.value,
-          cvrDelta: data.summary?.cvr?.delta,
+          productPageCvrValue: data.summary?.product_page_cvr?.value,
+          productPageCvrDelta: data.summary?.product_page_cvr?.delta,
+          impressionsCvrValue: data.summary?.impressions_cvr?.value,
+          impressionsCvrDelta: data.summary?.impressions_cvr?.delta,
           impressionsValue: data.summary?.impressions?.value,
           impressionsDelta: data.summary?.impressions?.delta
         }

--- a/src/hooks/useComparisonData.test.tsx
+++ b/src/hooks/useComparisonData.test.tsx
@@ -26,7 +26,8 @@ describe('useComparisonData', () => {
       impressions: { value: 210, delta: 5 },
       downloads: { value: 105, delta: 10 },
       product_page_views: { value: 420, delta: 7 },
-      cvr: { value: 50, delta: 3 },
+      product_page_cvr: { value: 50, delta: 3 },
+      impressions_cvr: { value: 25, delta: 2 },
     },
     timeseriesData: mockTimeseriesData,
     trafficSources: [

--- a/src/hooks/useComparisonData.ts
+++ b/src/hooks/useComparisonData.ts
@@ -20,7 +20,8 @@ export interface ComparisonData {
     impressions: number;
     downloads: number;
     product_page_views: number;
-    cvr: number;
+    product_page_cvr: number;
+    impressions_cvr: number;
   } | null;
 }
 

--- a/src/pages/conversion-analysis.test.tsx
+++ b/src/pages/conversion-analysis.test.tsx
@@ -53,15 +53,16 @@ describe('ConversionAnalysisPage', () => {
     summary: {
       impressions: { value: 100000, delta: 2.5 },
       downloads: { value: 50000, delta: 3.7 },
-      pageViews: { value: 75000, delta: 1.2 },
-      cvr: { value: 5.2, delta: 0.8 },
+      product_page_views: { value: 75000, delta: 1.2 },
+      product_page_cvr: { value: 66.7, delta: 2.1 },
+      impressions_cvr: { value: 5.2, delta: 0.8 },
     },
     timeseriesData: [
       {
         date: '2023-01-01',
         impressions: 1000,
         downloads: 500,
-        pageViews: 750,
+        product_page_views: 750,
       }
     ],
     trafficSources: [
@@ -79,14 +80,15 @@ describe('ConversionAnalysisPage', () => {
     });
   });
 
-  it('renders the main conversion rate card correctly', () => {
+  it('renders the main conversion rate cards correctly', () => {
     render(<ConversionAnalysisPage />);
-    
+
     // Check if the page title is rendered
     expect(screen.getByText('Conversion Analysis')).toBeInTheDocument();
-    
-    // Check if the main CVR card is rendered
-    expect(screen.getByTestId('kpi-card-Conversion Rate')).toBeInTheDocument();
+
+    // Check if both CVR cards are rendered
+    expect(screen.getByTestId('kpi-card-Product Page CVR')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-card-Impressions CVR')).toBeInTheDocument();
   });
 
   it('renders traffic source cards correctly', () => {

--- a/src/pages/conversion-analysis.tsx
+++ b/src/pages/conversion-analysis.tsx
@@ -66,12 +66,21 @@ const ConversionAnalysisPage: React.FC = () => {
         {/* Cumulative Section */}
         <section>
           <h2 className="text-xl font-semibold mb-4">Cumulative</h2>
-          <div className="flex justify-center">
+          <div className="flex justify-center gap-4">
             <div className="w-64">
               <KpiCard
-                title="Conversion Rate"
-                value={data.summary.cvr.value}
-                delta={data.summary.cvr.delta}
+                title="Product Page CVR"
+                value={data.summary.product_page_cvr.value}
+                delta={data.summary.product_page_cvr.delta}
+                isPercentage
+              />
+            </div>
+            <div className="w-64">
+              <KpiCard
+                title="Impressions CVR"
+                value={data.summary.impressions_cvr.value}
+                delta={data.summary.impressions_cvr.delta}
+                isPercentage
               />
             </div>
           </div>
@@ -79,7 +88,7 @@ const ConversionAnalysisPage: React.FC = () => {
         
         <section className="mt-8">
           <div className="flex flex-col md:flex-row justify-between items-start gap-4 mb-4">
-            <h2 className="text-xl font-semibold">Conversion Rate Over Time</h2>
+            <h2 className="text-xl font-semibold">Conversion Rates Over Time</h2>
             <TrafficSourceSelect 
               selectedSources={selectedSources} 
               onSourceChange={setSelectedSources} 

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -138,7 +138,7 @@ const OverviewPage: React.FC = () => {
                   </PremiumTypography.SectionTitle>
                 </PremiumCardHeader>
                 <PremiumCardContent className="p-8">
-                  <ResponsiveGrid cols={{ default: 1, md: 3 }} gap="lg">
+                  <ResponsiveGrid cols={{ default: 1, md: 4 }} gap="lg">
                     <div className="text-center group">
                       <PremiumTypography.DataLabel className="mb-3 block">Total Impressions</PremiumTypography.DataLabel>
                       <PremiumTypography.MetricValue className="group-hover:text-blue-400 transition-colors">
@@ -152,9 +152,15 @@ const OverviewPage: React.FC = () => {
                       </PremiumTypography.MetricValue>
                     </div>
                     <div className="text-center group">
-                      <PremiumTypography.DataLabel className="mb-3 block">Conversion Rate</PremiumTypography.DataLabel>
+                      <PremiumTypography.DataLabel className="mb-3 block">Product Page CVR</PremiumTypography.DataLabel>
                       <PremiumTypography.MetricValue className="text-orange-500 group-hover:text-orange-400 transition-colors">
-                        {(data.summary.cvr ? data.summary.cvr.value : 0).toFixed(2)}%
+                        {(data.summary.product_page_cvr ? data.summary.product_page_cvr.value : 0).toFixed(2)}%
+                      </PremiumTypography.MetricValue>
+                    </div>
+                    <div className="text-center group">
+                      <PremiumTypography.DataLabel className="mb-3 block">Impressions CVR</PremiumTypography.DataLabel>
+                      <PremiumTypography.MetricValue className="text-orange-500 group-hover:text-orange-400 transition-colors">
+                        {(data.summary.impressions_cvr ? data.summary.impressions_cvr.value : 0).toFixed(2)}%
                       </PremiumTypography.MetricValue>
                     </div>
                   </ResponsiveGrid>

--- a/src/utils/dateCalculations.ts
+++ b/src/utils/dateCalculations.ts
@@ -45,13 +45,34 @@ export const calculateDeltas = (
   current: { impressions: number; downloads: number; product_page_views: number },
   previous: { impressions: number; downloads: number; product_page_views: number }
 ) => {
+  const currentProductPageCvr =
+    current.product_page_views > 0
+      ? (current.downloads / current.product_page_views) * 100
+      : 0;
+  const previousProductPageCvr =
+    previous.product_page_views > 0
+      ? (previous.downloads / previous.product_page_views) * 100
+      : 0;
+
+  const currentImpressionsCvr =
+    current.impressions > 0 ? (current.downloads / current.impressions) * 100 : 0;
+  const previousImpressionsCvr =
+    previous.impressions > 0 ? (previous.downloads / previous.impressions) * 100 : 0;
+
   return {
     impressions: calculatePercentageChange(current.impressions, previous.impressions),
     downloads: calculatePercentageChange(current.downloads, previous.downloads),
-    product_page_views: calculatePercentageChange(current.product_page_views, previous.product_page_views),
-    cvr: calculatePercentageChange(
-      current.impressions > 0 ? (current.downloads / current.impressions) * 100 : 0,
-      previous.impressions > 0 ? (previous.downloads / previous.impressions) * 100 : 0
+    product_page_views: calculatePercentageChange(
+      current.product_page_views,
+      previous.product_page_views
+    ),
+    product_page_cvr: calculatePercentageChange(
+      currentProductPageCvr,
+      previousProductPageCvr
+    ),
+    impressions_cvr: calculatePercentageChange(
+      currentImpressionsCvr,
+      previousImpressionsCvr
     )
   };
 };


### PR DESCRIPTION
## Summary
- replace legacy single CVR references with product page and impressions CVR metrics
- update comparison utilities, overview and conversion analysis pages for dual CVR
- revise tests and add CVR reference inventory
