### PR TITLE
Preserve data during refetch and add regression tests

### DIFF
--- a/src/hooks/__tests__/useAsoDataWithFallback.test.tsx
+++ b/src/hooks/__tests__/useAsoDataWithFallback.test.tsx
@@ -1,0 +1,83 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAsoDataWithFallback } from '../useAsoDataWithFallback';
+import { useBigQueryData } from '../useBigQueryData';
+import { useMockAsoData } from '../useMockAsoData';
+import { useBigQueryAppSelection } from '@/context/BigQueryAppContext';
+import { useAuth } from '@/context/AuthContext';
+
+jest.mock('../useBigQueryData');
+jest.mock('../useMockAsoData');
+jest.mock('@/context/BigQueryAppContext', () => ({
+  useBigQueryAppSelection: jest.fn(() => ({ selectedApps: [] }))
+}));
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: jest.fn(() => ({ user: null }))
+}));
+jest.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: jest.fn() }
+}));
+
+describe('useAsoDataWithFallback', () => {
+  const dateRange = { from: new Date('2023-01-01'), to: new Date('2023-01-02') };
+  const sources = ['organic'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('preserves previous data during BigQuery refetch', async () => {
+    const bigQueryData = { summary: { impressions: { value: 1 }, downloads: { value: 1 }, product_page_views: { value: 1 } }, timeseriesData: [], trafficSources: [] };
+
+    useBigQueryData
+      .mockReturnValueOnce({
+        data: bigQueryData,
+        loading: false,
+        error: null,
+        availableTrafficSources: []
+      })
+      .mockReturnValue({
+        data: null,
+        loading: true,
+        error: null,
+        availableTrafficSources: []
+      });
+
+    useMockAsoData.mockReturnValue({ data: null, loading: false, error: null });
+
+    const { result, rerender } = renderHook(() =>
+      useAsoDataWithFallback(dateRange, sources)
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const initialData = result.current.data;
+
+    rerender();
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    expect(result.current.data).toBe(initialData);
+  });
+
+  it('surfaces mock error when BigQuery and mock fail', async () => {
+    const bigQueryError = new Error('BigQuery failed');
+    const mockError = new Error('Mock failed');
+
+    useBigQueryData.mockReturnValue({
+      data: null,
+      loading: false,
+      error: bigQueryError,
+      availableTrafficSources: []
+    });
+
+    useMockAsoData.mockReturnValue({
+      data: null,
+      loading: false,
+      error: mockError
+    });
+
+    const { result } = renderHook(() =>
+      useAsoDataWithFallback(dateRange, sources)
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe(mockError);
+  });
+});

--- a/src/hooks/__tests__/useComparisonData.test.tsx
+++ b/src/hooks/__tests__/useComparisonData.test.tsx
@@ -1,0 +1,74 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useComparisonData } from '../useComparisonData';
+import { useAsoData } from '../../context/AsoDataContext';
+import { useBigQueryData } from '../useBigQueryData';
+import { standardizeChartData } from '../../utils/format';
+
+jest.mock('../../context/AsoDataContext', () => ({
+  useAsoData: jest.fn()
+}));
+jest.mock('../useBigQueryData');
+jest.mock('../../utils/format', () => ({
+  standardizeChartData: jest.fn((d) => d)
+}));
+
+describe('useComparisonData - refetch preservation', () => {
+  const dateRange = { from: new Date('2023-01-01'), to: new Date('2023-01-02') };
+  const filters = { dateRange, trafficSources: [] };
+
+  const currentData = {
+    summary: {
+      impressions: { value: 100 },
+      downloads: { value: 10 },
+      product_page_views: { value: 50 }
+    },
+    timeseriesData: [],
+    trafficSources: []
+  };
+
+  const previousData = {
+    summary: {
+      impressions: { value: 80 },
+      downloads: { value: 8 },
+      product_page_views: { value: 40 }
+    },
+    timeseriesData: [],
+    trafficSources: []
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAsoData.mockReturnValue({
+      data: currentData,
+      loading: false,
+      error: null,
+      filters
+    });
+  });
+
+  it('keeps previous comparison data during refetch', async () => {
+    useBigQueryData
+      .mockReturnValueOnce({
+        data: previousData,
+        loading: false,
+        error: null
+      })
+      .mockReturnValue({
+        data: null,
+        loading: true,
+        error: null
+      });
+
+    const { result, rerender } = renderHook(() => useComparisonData('period'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const cachedPrev = result.current.previous;
+    const cachedDeltas = result.current.deltas;
+
+    rerender();
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    expect(result.current.previous).toBe(cachedPrev);
+    expect(result.current.deltas).toBe(cachedDeltas);
+  });
+});


### PR DESCRIPTION
## Summary
- surface mock fallback errors in `useAsoDataWithFallback`
- cache last comparison results to avoid flicker during refetch
- add regression tests for data retention and error propagation
