### PR TITLE
feat: enable client-side traffic source filtering

### DIFF
--- a/src/utils/filterByTrafficSources.ts
+++ b/src/utils/filterByTrafficSources.ts
@@ -1,0 +1,9 @@
+import { BigQueryDataPoint } from '@/hooks/useBigQueryData';
+
+export const filterByTrafficSources = (
+  data: BigQueryDataPoint[],
+  selectedSources: string[]
+): BigQueryDataPoint[] => {
+  if (!data || selectedSources.length === 0) return data;
+  return data.filter((point) => selectedSources.includes(point.traffic_source));
+};


### PR DESCRIPTION
## Summary
- fetch all traffic sources once in useBigQueryData and filter locally
- add filterByTrafficSources utility for client-side filtering
