### PR TITLE
feat: enhance insights card design and traffic matrix

### DIFF
--- a/src/components/InsightCard.tsx
+++ b/src/components/InsightCard.tsx
@@ -9,7 +9,14 @@ interface InsightCardProps {
   preview: string;
   href: string;
   icon: LucideIcon;
-  status?: 'optimization-needed' | 'critical' | string;
+  type?:
+    | 'traffic-performance'
+    | 'anomaly-detection'
+    | 'correlations'
+    | 'efficiency'
+    | 'patterns'
+    | string;
+  status?: 'optimization-needed' | 'critical' | 'healthy' | string;
   metrics?: {
     scale: number;
     optimize: number;
@@ -18,9 +25,51 @@ interface InsightCardProps {
   };
 }
 
-const statusStyles: Record<string, string> = {
-  'optimization-needed': 'border-orange-500',
-  critical: 'border-red-500',
+const getIconBackground = (type?: string) => {
+  switch (type) {
+    case 'traffic-performance':
+      return 'bg-orange-500/20';
+    case 'anomaly-detection':
+      return 'bg-red-500/20';
+    case 'correlations':
+      return 'bg-blue-500/20';
+    case 'efficiency':
+      return 'bg-green-500/20';
+    case 'patterns':
+      return 'bg-purple-500/20';
+    default:
+      return 'bg-gray-500/20';
+  }
+};
+
+const getIconColor = (type?: string) => {
+  switch (type) {
+    case 'traffic-performance':
+      return 'text-orange-400';
+    case 'anomaly-detection':
+      return 'text-red-400';
+    case 'correlations':
+      return 'text-blue-400';
+    case 'efficiency':
+      return 'text-green-400';
+    case 'patterns':
+      return 'text-purple-400';
+    default:
+      return 'text-gray-400';
+  }
+};
+
+const getStatusColor = (status?: string) => {
+  switch (status) {
+    case 'critical':
+      return 'bg-red-500 text-white';
+    case 'optimization-needed':
+      return 'bg-orange-500 text-white';
+    case 'healthy':
+      return 'bg-green-500 text-white';
+    default:
+      return 'bg-gray-500 text-white';
+  }
 };
 
 const InsightCard: React.FC<InsightCardProps> = ({
@@ -31,45 +80,57 @@ const InsightCard: React.FC<InsightCardProps> = ({
   icon: Icon,
   status,
   metrics,
+  type,
 }) => {
   return (
     <Link
       to={href}
-      className={`block bg-white rounded-xl border p-6 hover:shadow-md transition-shadow ${status ? statusStyles[status] : 'border-gray-200'}`}
+      className={`group bg-gray-800 hover:bg-gray-750 border border-gray-700 hover:border-orange-500 rounded-xl p-6 transition-all duration-200 cursor-pointer transform hover:scale-105 ${
+        status === 'critical' ? 'border-red-500/50 bg-red-900/10' : ''
+      } ${
+        status === 'optimization-needed'
+          ? 'border-orange-500/50 bg-orange-900/10'
+          : ''
+      }`}
     >
-      <div className="flex items-start justify-between">
+      <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
-          <div className="p-2 bg-orange-100 rounded-lg">
-            <Icon className="h-5 w-5 text-orange-600" />
+          <div className={`p-3 rounded-lg ${getIconBackground(type)}`}>
+            <Icon className={`h-6 w-6 ${getIconColor(type)}`} />
           </div>
           <div>
-            <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
-            <p className="text-sm text-gray-500">{subtitle}</p>
+            <h3 className="text-lg font-semibold text-white group-hover:text-orange-400 transition-colors">
+              {title}
+            </h3>
+            <p className="text-gray-400 text-sm">{subtitle}</p>
           </div>
         </div>
-        <ArrowRight className="h-5 w-5 text-gray-400" />
+        {status && (
+          <div className={`px-3 py-1 rounded-full text-xs font-bold ${getStatusColor(status)}`}>
+            {status.replace('-', ' ').toUpperCase()}
+          </div>
+        )}
       </div>
-      <p className="mt-4 text-sm text-gray-700">{preview}</p>
+
       {metrics && (
-        <div className="grid grid-cols-4 gap-2 mt-4 text-center">
-          <div>
-            <div className="text-lg font-bold text-gray-900">{metrics.scale}</div>
-            <div className="text-xs text-gray-500">Scale</div>
-          </div>
-          <div>
-            <div className="text-lg font-bold text-gray-900">{metrics.optimize}</div>
-            <div className="text-xs text-gray-500">Optimize</div>
-          </div>
-          <div>
-            <div className="text-lg font-bold text-gray-900">{metrics.investigate}</div>
-            <div className="text-xs text-gray-500">Investigate</div>
-          </div>
-          <div>
-            <div className="text-lg font-bold text-gray-900">{metrics.expand}</div>
-            <div className="text-xs text-gray-500">Expand</div>
-          </div>
+        <div className="grid grid-cols-4 gap-4 mb-4">
+          {Object.entries(metrics).map(([key, value]) => (
+            <div key={key} className="text-center">
+              <div className="text-2xl font-bold text-white">{value}</div>
+              <div className="text-xs text-gray-400 capitalize">{key}</div>
+            </div>
+          ))}
         </div>
       )}
+
+      <div className="bg-gray-700 rounded-lg p-3 mb-4">
+        <div className="text-sm text-gray-300">{preview}</div>
+      </div>
+
+      <div className="w-full bg-orange-500 hover:bg-orange-600 text-white font-medium py-2 px-4 rounded-lg transition-colors flex items-center justify-center gap-2">
+        View Details
+        <ArrowRight className="h-4 w-4" />
+      </div>
     </Link>
   );
 };

--- a/src/pages/insights.tsx
+++ b/src/pages/insights.tsx
@@ -50,6 +50,7 @@ const InsightsPage: React.FC = () => {
             preview={`${categorized.optimize.length} sources need optimization`}
             href="/insights/traffic-performance"
             icon={Target}
+            type="traffic-performance"
             status="optimization-needed"
             metrics={{
               scale: categorized.scale.length,
@@ -64,6 +65,7 @@ const InsightsPage: React.FC = () => {
             preview="7 critical anomalies detected"
             href="/insights/anomalies"
             icon={AlertTriangle}
+            type="anomaly-detection"
             status="critical"
           />
         </div>


### PR DESCRIPTION
## Summary
- Restyle Insight cards to match dark orange branding, including type-based icon colors and status indicators
- Add `type` support for InsightCard usages on the insights hub
- Introduce traffic source categorization with strategic context, empty quadrant messaging, recommended actions, and data validation in Traffic Performance Matrix

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors in unrelated files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b7f8fe4bc83269e362a526d644708