### PR TITLE
feat: simplify analytics KPI selector and cards

### DIFF
--- a/src/components/KPISelector.tsx
+++ b/src/components/KPISelector.tsx
@@ -26,17 +26,25 @@ interface KPISelectorProps {
   value: string;
   onChange: (value: string) => void;
   className?: string;
+  includeAllOption?: boolean;
 }
 
-export const KPISelector: React.FC<KPISelectorProps> = ({ value, onChange, className = '' }) => {
+export const KPISelector: React.FC<KPISelectorProps> = ({ value, onChange, className = '', includeAllOption = true }) => {
+  const options = includeAllOption
+    ? KPI_OPTIONS
+    : KPI_OPTIONS.filter((option) => option.id !== 'all');
   return (
     <Select value={value} onValueChange={onChange}>
       <SelectTrigger className={`w-48 h-8 bg-zinc-800 border-zinc-700 text-foreground ${className}`}>
         <SelectValue placeholder="Select KPI" />
       </SelectTrigger>
       <SelectContent className="bg-zinc-800 border-zinc-700">
-        {KPI_OPTIONS.map((option) => (
-          <SelectItem key={option.id} value={option.id} className="text-foreground hover:bg-zinc-700">
+        {options.map((option) => (
+          <SelectItem
+            key={option.id}
+            value={option.id}
+            className="text-foreground hover:bg-zinc-700"
+          >
             {option.label}
           </SelectItem>
         ))}

--- a/src/components/TrafficSourceKpiCards.tsx
+++ b/src/components/TrafficSourceKpiCards.tsx
@@ -6,8 +6,9 @@ import { formatPercentage } from '@/utils/format';
 interface TrafficSourceKpiCardsProps {
   sources: TrafficSource[];
   selectedKPI: string;
-  onSourceClick: (sourceName: string) => void;
   summary: AsoMetrics;
+  disableClicks?: boolean;
+  onSourceClick?: (sourceName: string) => void;
 }
 
 const getKPIValueForTrafficSource = (source: TrafficSource, kpiId: string): MetricSummary => {
@@ -26,7 +27,13 @@ const categorizeTrafficSource = (metric: MetricSummary, threshold: number) => {
   return { action: 'Monitor', color: 'text-zinc-500' };
 };
 
-export const TrafficSourceKpiCards: React.FC<TrafficSourceKpiCardsProps> = ({ sources, selectedKPI, onSourceClick, summary }) => {
+export const TrafficSourceKpiCards: React.FC<TrafficSourceKpiCardsProps> = ({
+  sources,
+  selectedKPI,
+  summary,
+  disableClicks = false,
+  onSourceClick,
+}) => {
   const threshold = summary && (summary as any)[selectedKPI]
     ? ((summary as any)[selectedKPI].value || 0) * 0.1
     : 0;
@@ -46,8 +53,13 @@ export const TrafficSourceKpiCards: React.FC<TrafficSourceKpiCardsProps> = ({ so
         const displayValue = isPercentage
           ? `${metric.value.toFixed(2)}%`
           : metric.value.toLocaleString();
+        const clickable = !disableClicks && !!onSourceClick;
         return (
-          <Card key={source.name} className="bg-zinc-800 hover:bg-zinc-700 cursor-pointer" onClick={() => onSourceClick(source.name)}>
+          <Card
+            key={source.name}
+            className={`bg-zinc-800 ${clickable ? 'hover:bg-zinc-700 cursor-pointer' : ''}`}
+            onClick={clickable ? () => onSourceClick!(source.name) : undefined}
+          >
             <CardHeader className="pb-2 flex flex-row items-center justify-between space-y-0">
               <CardTitle className="text-sm font-medium">{source.name}</CardTitle>
               <span className={`text-xs font-semibold ${category.color}`}>{category.action}</span>

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -24,7 +24,7 @@ import { TrafficSourceKpiCards } from '../components/TrafficSourceKpiCards';
 const Dashboard: React.FC = () => {
   const [excludeAsa, setExcludeAsa] = useState(false);
   const [selectedMetric, setSelectedMetric] = useState('downloads');
-  const [selectedKPI, setSelectedKPI] = useState<string>('downloads');
+  const [selectedKPI, setSelectedKPI] = useState<string>('impressions');
   const navigate = useNavigate();
   const {
     data,
@@ -78,10 +78,6 @@ const Dashboard: React.FC = () => {
 
   const handleKPIChange = (value: string) => {
     setSelectedKPI(value);
-  };
-
-  const handleTrafficSourceClick = (sourceName: string) => {
-    handleTrafficSourceChange([sourceName]);
   };
 
 
@@ -148,12 +144,10 @@ const Dashboard: React.FC = () => {
   const impressionsCvrDelta = data.summary?.impressions_cvr?.delta || 0;
 
   const shouldShowKPI = (kpiId: string) => {
-    return selectedKPI === 'all' || selectedKPI === kpiId;
+    return selectedKPI === kpiId;
   };
 
-  const visibleKPIs = selectedKPI === 'all'
-    ? ['impressions', 'downloads', 'product_page_views', 'product_page_cvr', 'impressions_cvr']
-    : [selectedKPI];
+  const visibleKPIs = [selectedKPI];
 
   const gridColsClass: Record<number, string> = {
     1: 'xl:grid-cols-1',
@@ -245,7 +239,11 @@ const Dashboard: React.FC = () => {
         </div>
 
         <div className="flex items-center gap-4">
-          <KPISelector value={selectedKPI} onChange={handleKPIChange} />
+          <KPISelector
+            value={selectedKPI}
+            onChange={handleKPIChange}
+            includeAllOption={false}
+          />
           <Button
             variant={excludeAsa ? "destructive" : "outline"}
             size="sm"
@@ -261,9 +259,9 @@ const Dashboard: React.FC = () => {
       {data.trafficSources && (
         <TrafficSourceKpiCards
           sources={data.trafficSources}
-          selectedKPI={selectedKPI === 'all' ? 'downloads' : selectedKPI}
-          onSourceClick={handleTrafficSourceClick}
+          selectedKPI={selectedKPI}
           summary={data.summary}
+          disableClicks
         />
       )}
 


### PR DESCRIPTION
## Summary
- remove `All KPIs` option on analytics dashboard
- disable traffic source card clicks for analytics view
- default analytics KPI selection to Impressions
