### PR TITLE
feat: add traffic source selector to executive dashboard

### DIFF
--- a/src/components/TrafficSourceSelector.tsx
+++ b/src/components/TrafficSourceSelector.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+interface TrafficSourceSelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+const TRAFFIC_SOURCE_OPTIONS = [
+  { value: 'all', label: 'All Sources' },
+  { value: 'individual', label: 'Individual Sources' },
+  { value: 'organic', label: 'Organic Sources' },
+  { value: 'paid', label: 'Paid Sources' },
+  { value: 'external', label: 'External Sources' },
+];
+
+export const TrafficSourceSelector: React.FC<TrafficSourceSelectorProps> = ({ value, onChange, className = '' }) => (
+  <Select value={value} onValueChange={onChange}>
+    <SelectTrigger className={`w-48 h-8 bg-zinc-800 border-zinc-700 text-foreground ${className}`}>
+      <SelectValue placeholder="Select Source" />
+    </SelectTrigger>
+    <SelectContent className="bg-zinc-800 border-zinc-700">
+      {TRAFFIC_SOURCE_OPTIONS.map((option) => (
+        <SelectItem key={option.value} value={option.value} className="text-foreground hover:bg-zinc-700">
+          {option.label}
+        </SelectItem>
+      ))}
+    </SelectContent>
+  </Select>
+);
+
+export default TrafficSourceSelector;

--- a/src/utils/trafficSourceGroups.ts
+++ b/src/utils/trafficSourceGroups.ts
@@ -1,0 +1,52 @@
+import { TrafficSourceTimeSeriesPoint, TimeSeriesPoint } from '@/hooks/useMockAsoData';
+
+export const trafficSourceGroups: Record<string, string[]> = {
+  organic: ['App Store Search', 'App Store Browse', 'App Referrer'],
+  paid: ['Apple Search Ads'],
+  external: ['Web Referrer', 'Event Notification'],
+  other: ['Institutional Purchase', 'Other'],
+};
+
+const sourceKeyMap: Record<string, string> = {
+  'App Store Search': 'appStoreSearch',
+  'App Store Browse': 'appStoreBrowse',
+  'App Referrer': 'appReferrer',
+  'Apple Search Ads': 'appleSearchAds',
+  'Web Referrer': 'webReferrer',
+  'Event Notification': 'eventNotification',
+  'Institutional Purchase': 'institutionalPurchase',
+  Other: 'other',
+};
+
+export function aggregateTrafficSources(
+  data: TrafficSourceTimeSeriesPoint[] = [],
+  sources: string[]
+): TimeSeriesPoint[] {
+  return data.map((item) => {
+    let impressions = 0;
+    let downloads = 0;
+    let product_page_views = 0;
+
+    const record = item as unknown as Record<string, number>;
+    for (const source of sources) {
+      const key = sourceKeyMap[source];
+      impressions += record[`${key}_impressions`] || 0;
+      downloads += record[`${key}_downloads`] || 0;
+      product_page_views += record[`${key}_product_page_views`] || 0;
+    }
+
+    const product_page_cvr =
+      product_page_views > 0 ? (downloads / product_page_views) * 100 : 0;
+    const impressions_cvr =
+      impressions > 0 ? (downloads / impressions) * 100 : 0;
+
+    return {
+      date: item.date,
+      impressions,
+      downloads,
+      product_page_views,
+      product_page_cvr,
+      impressions_cvr,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- simplify time series chart controls and add traffic source selector
- support traffic source grouping logic for executive overview
- show impressions, downloads, and page views without KPI toggle
