### PR TITLE
feat: add executive dashboard traffic source multi-select

### DIFF
--- a/src/components/ExecutiveTimeSeriesChart.tsx
+++ b/src/components/ExecutiveTimeSeriesChart.tsx
@@ -1,0 +1,262 @@
+import React, { useState, useMemo, useEffect } from "react";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts";
+import { TimeSeriesPoint, TrafficSourceTimeSeriesPoint } from "@/hooks/useMockAsoData";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { chartColors } from "@/utils/chartConfig";
+import { TRAFFIC_SOURCE_COLORS } from "@/utils/trafficSourceColors";
+
+const sourceKeyMap: Record<string, string> = {
+  "App Store Search": "appStoreSearch",
+  "App Store Browse": "appStoreBrowse",
+  "App Referrer": "appReferrer",
+  "Apple Search Ads": "appleSearchAds",
+  "Web Referrer": "webReferrer",
+};
+
+interface ExecutiveTimeSeriesChartProps {
+  data: TimeSeriesPoint[];
+  selectedKPI?: string;
+  trafficSourceTimeseriesData?: TrafficSourceTimeSeriesPoint[];
+  mode?: "total" | "breakdown";
+  showModeToggle?: boolean;
+  visibleMetrics?: string[];
+  breakdownMetric?: "impressions" | "downloads" | "product_page_views";
+  selectedTrafficSources?: string[];
+}
+
+const ExecutiveTimeSeriesChart: React.FC<ExecutiveTimeSeriesChartProps> = React.memo(
+  ({
+    data,
+    selectedKPI = "all",
+    trafficSourceTimeseriesData = [],
+    mode = "total",
+    showModeToggle = true,
+    visibleMetrics = [
+      "impressions",
+      "downloads",
+      "product_page_views",
+      "product_page_cvr",
+      "impressions_cvr",
+    ],
+    breakdownMetric = "downloads",
+    selectedTrafficSources = [
+      "App Store Search",
+      "App Store Browse",
+      "Apple Search Ads",
+      "App Referrer",
+      "Web Referrer",
+    ],
+  }) => {
+    const [chartMode, setChartMode] = useState<"total" | "breakdown">(mode);
+
+  useEffect(() => {
+    setChartMode(mode);
+  }, [mode]);
+
+  const formattedData = useMemo(() => data.map(item => {
+    const product_page_cvr = item.product_page_views > 0
+      ? (item.downloads / item.product_page_views) * 100
+      : 0;
+    const impressions_cvr = item.impressions > 0
+      ? (item.downloads / item.impressions) * 100
+      : 0;
+    return {
+      ...item,
+      product_page_cvr,
+      impressions_cvr,
+      date: new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    };
+  }), [data]);
+
+  const formattedTrafficData = useMemo(
+    () =>
+      trafficSourceTimeseriesData.map((item) => {
+        const record = item as unknown as Record<string, number>;
+        const base: Record<string, number | string> = {
+          date: new Date(item.date).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+          }),
+        };
+        selectedTrafficSources.forEach((source) => {
+          const key = sourceKeyMap[source];
+          base[key] = record[`${key}_${breakdownMetric}`] || 0;
+        });
+        return base;
+      }),
+    [trafficSourceTimeseriesData, breakdownMetric, selectedTrafficSources]
+  );
+
+  const chartData = chartMode === "breakdown" ? formattedTrafficData : formattedData;
+
+  const chartConfigObj = useMemo(() => {
+    if (chartMode === "breakdown") {
+      return selectedTrafficSources.reduce((acc, source) => {
+        const key = sourceKeyMap[source];
+        acc[key] = { label: source, color: TRAFFIC_SOURCE_COLORS[source] };
+        return acc;
+      }, {} as Record<string, { label: string; color: string }>) as ChartConfig;
+    }
+    const base = {
+      impressions: { label: "Impressions", color: chartColors.impressions },
+      downloads: { label: "Downloads", color: chartColors.downloads },
+      product_page_views: {
+        label: "Product Page Views",
+        color: chartColors.product_page_views,
+      },
+      product_page_cvr: {
+        label: "Product Page CVR",
+        color: chartColors.product_page_cvr,
+      },
+      impressions_cvr: {
+        label: "Impressions CVR",
+        color: chartColors.impressions_cvr,
+      },
+    };
+    return Object.fromEntries(
+      Object.entries(base).filter(([key]) => visibleMetrics.includes(key))
+    ) as ChartConfig;
+  }, [chartMode, visibleMetrics, selectedTrafficSources]);
+
+  const showLine = (metric: string) =>
+    visibleMetrics.includes(metric) && (selectedKPI === 'all' || selectedKPI === metric);
+  const getOpacity = (metric: string) => (showLine(metric) ? 1 : 0.2);
+
+  return (
+    <div className="w-full h-[450px] space-y-4">
+      {showModeToggle && (
+        <div className="flex justify-end">
+          <div className="flex bg-gray-100 rounded-lg p-1">
+            <button
+              onClick={() => setChartMode('total')}
+              className={`px-3 py-1 rounded ${chartMode === 'total' ? 'bg-white shadow' : ''}`}
+            >
+              Total Performance
+            </button>
+            <button
+              onClick={() => setChartMode('breakdown')}
+              className={`px-3 py-1 rounded ${chartMode === 'breakdown' ? 'bg-white shadow' : ''}`}
+            >
+              By Traffic Source
+            </button>
+          </div>
+        </div>
+      )}
+      <ChartContainer config={chartConfigObj} className="w-full h-full">
+        <LineChart data={chartData} accessibilityLayer>
+          <CartesianGrid vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            tickFormatter={(value) => {
+              if (window.innerWidth < 768) {
+                return value.split(' ')[1];
+              }
+              return value;
+            }}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            tickFormatter={(value) => value.toLocaleString()}
+            width={60}
+          />
+          <ChartTooltip
+            cursor={false}
+            content={<ChartTooltipContent indicator="dot" />}
+          />
+          <ChartLegend content={<ChartLegendContent />} />
+          {chartMode === 'total' ? (
+            <>
+              {showLine('impressions') && (
+                <Line
+                  type="monotone"
+                  dataKey="impressions"
+                  stroke="var(--color-impressions)"
+                  strokeWidth={2}
+                  strokeOpacity={getOpacity('impressions')}
+                  dot={false}
+                  activeDot={{ r: 6 }}
+                />
+              )}
+              {showLine('downloads') && (
+                <Line
+                  type="monotone"
+                  dataKey="downloads"
+                  stroke="var(--color-downloads)"
+                  strokeWidth={2}
+                  strokeOpacity={getOpacity('downloads')}
+                  dot={false}
+                  activeDot={{ r: 6 }}
+                />
+              )}
+              {showLine('product_page_views') && (
+                <Line
+                  type="monotone"
+                  dataKey="product_page_views"
+                  stroke="var(--color-product_page_views)"
+                  strokeWidth={2}
+                  strokeOpacity={getOpacity('product_page_views')}
+                  dot={false}
+                  activeDot={{ r: 6 }}
+                />
+              )}
+              {showLine('product_page_cvr') && (
+                <Line
+                  type="monotone"
+                  dataKey="product_page_cvr"
+                  stroke="var(--color-product_page_cvr)"
+                  strokeWidth={2}
+                  strokeOpacity={getOpacity('product_page_cvr')}
+                  dot={false}
+                  activeDot={{ r: 6 }}
+                />
+              )}
+              {showLine('impressions_cvr') && (
+                <Line
+                  type="monotone"
+                  dataKey="impressions_cvr"
+                  stroke="var(--color-impressions_cvr)"
+                  strokeWidth={2}
+                  strokeOpacity={getOpacity('impressions_cvr')}
+                  dot={false}
+                  activeDot={{ r: 6 }}
+                />
+              )}
+            </>
+          ) : (
+            <>
+              {selectedTrafficSources.map((source) => {
+                const key = sourceKeyMap[source];
+                return (
+                  <Line
+                    key={key}
+                    type="monotone"
+                    dataKey={key}
+                    stroke={`var(--color-${key})`}
+                    strokeWidth={2}
+                    dot={false}
+                    activeDot={{ r: 6 }}
+                  />
+                );
+              })}
+            </>
+          )}
+        </LineChart>
+      </ChartContainer>
+    </div>
+  );
+});
+
+ExecutiveTimeSeriesChart.displayName = "ExecutiveTimeSeriesChart";
+export default ExecutiveTimeSeriesChart;

--- a/src/components/TrafficSourceSelector.tsx
+++ b/src/components/TrafficSourceSelector.tsx
@@ -1,33 +1,87 @@
 import React from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 
 interface TrafficSourceSelectorProps {
   value: string;
   onChange: (value: string) => void;
+  selectedSources: string[];
+  onSelectedSourcesChange: (sources: string[]) => void;
+  availableSources: string[];
   className?: string;
 }
 
 const TRAFFIC_SOURCE_OPTIONS = [
   { value: 'all', label: 'All Sources' },
-  { value: 'individual', label: 'Individual Sources' },
   { value: 'organic', label: 'Organic Sources' },
   { value: 'paid', label: 'Paid Sources' },
-  { value: 'external', label: 'External Sources' },
+  { value: 'individual', label: 'Individual Sources' },
 ];
 
-export const TrafficSourceSelector: React.FC<TrafficSourceSelectorProps> = ({ value, onChange, className = '' }) => (
-  <Select value={value} onValueChange={onChange}>
-    <SelectTrigger className={`w-48 h-8 bg-zinc-800 border-zinc-700 text-foreground ${className}`}>
-      <SelectValue placeholder="Select Source" />
-    </SelectTrigger>
-    <SelectContent className="bg-zinc-800 border-zinc-700">
-      {TRAFFIC_SOURCE_OPTIONS.map((option) => (
-        <SelectItem key={option.value} value={option.value} className="text-foreground hover:bg-zinc-700">
-          {option.label}
-        </SelectItem>
-      ))}
-    </SelectContent>
-  </Select>
-);
+export const TrafficSourceSelector: React.FC<TrafficSourceSelectorProps> = ({
+  value,
+  onChange,
+  selectedSources,
+  onSelectedSourcesChange,
+  availableSources,
+  className = '',
+}) => {
+  const allSelected = selectedSources.length === availableSources.length;
+
+  const toggleSource = (source: string) => {
+    if (selectedSources.includes(source)) {
+      onSelectedSourcesChange(selectedSources.filter((s) => s !== source));
+    } else {
+      onSelectedSourcesChange([...selectedSources, source]);
+    }
+  };
+
+  const summaryText = allSelected
+    ? 'All Selected'
+    : selectedSources.length === 0
+    ? 'None Selected'
+    : selectedSources.join(', ');
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="w-48 h-8 bg-zinc-800 border-zinc-700 text-foreground">
+          <SelectValue placeholder="Select Source" />
+        </SelectTrigger>
+        <SelectContent className="bg-zinc-800 border-zinc-700">
+          {TRAFFIC_SOURCE_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value} className="text-foreground hover:bg-zinc-700">
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {value === 'individual' && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline" className="h-8 bg-zinc-800 border-zinc-700 text-foreground">
+              {summaryText}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="bg-zinc-800 border-zinc-700 p-2 w-56">
+            {availableSources.map((source) => (
+              <label key={source} className="flex items-center space-x-2 p-1">
+                <Checkbox
+                  checked={selectedSources.includes(source)}
+                  onCheckedChange={() => toggleSource(source)}
+                  className="border-zinc-600 data-[state=checked]:bg-yodel-orange data-[state=checked]:border-yodel-orange"
+                />
+                <span className="text-sm text-foreground">{source}</span>
+              </label>
+            ))}
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+};
 
 export default TrafficSourceSelector;

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -2,10 +2,14 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { useAsoData } from "../context/AsoDataContext";
 import { Skeleton } from "@/components/ui/skeleton";
-import TimeSeriesChart from "../components/TimeSeriesChart";
+import ExecutiveTimeSeriesChart from "../components/ExecutiveTimeSeriesChart";
 import KpiCard from "../components/KpiCard";
 import TrafficSourceSelector from "../components/TrafficSourceSelector";
-import { aggregateTrafficSources, trafficSourceGroups } from "@/utils/trafficSourceGroups";
+import {
+  aggregateTrafficSources,
+  executiveTrafficSourceGroups,
+  executiveTrafficSources,
+} from "@/utils/executiveTrafficSourceGroups";
 import {
   PremiumCard,
   PremiumCardHeader,
@@ -29,6 +33,7 @@ const OverviewPage: React.FC = () => {
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [trafficSourceView, setTrafficSourceView] = useState<string>('all');
+  const [selectedSources, setSelectedSources] = useState<string[]>([...executiveTrafficSources]);
 
   useEffect(() => {
     const fetchOrganizationId = async () => {
@@ -61,7 +66,9 @@ const OverviewPage: React.FC = () => {
     if (trafficSourceView === 'all' || trafficSourceView === 'individual') {
       return data.timeseriesData;
     }
-    const group = trafficSourceGroups[trafficSourceView as keyof typeof trafficSourceGroups];
+    const group = executiveTrafficSourceGroups[
+      trafficSourceView as keyof typeof executiveTrafficSourceGroups
+    ];
     return aggregateTrafficSources(trafficSourceTimeseries, group);
   }, [data, trafficSourceView, trafficSourceTimeseries]);
 
@@ -165,7 +172,13 @@ const OverviewPage: React.FC = () => {
                 </PremiumTypography.PageTitle>
 
                 <div className="flex gap-4">
-                  <TrafficSourceSelector value={trafficSourceView} onChange={setTrafficSourceView} />
+                  <TrafficSourceSelector
+                    value={trafficSourceView}
+                    onChange={setTrafficSourceView}
+                    selectedSources={selectedSources}
+                    onSelectedSourcesChange={setSelectedSources}
+                    availableSources={[...executiveTrafficSources]}
+                  />
                   <StatusIndicator status="success" pulse label="Live Data" />
                 </div>
               </div>
@@ -201,13 +214,14 @@ const OverviewPage: React.FC = () => {
                       </PremiumTypography.SectionTitle>
                     </PremiumCardHeader>
                     <PremiumCardContent className="p-8">
-                      <TimeSeriesChart
+                      <ExecutiveTimeSeriesChart
                         data={chartData}
                         trafficSourceTimeseriesData={trafficSourceTimeseries}
                         mode={chartMode}
                         showModeToggle={false}
                         visibleMetrics={['impressions','downloads','product_page_views']}
                         breakdownMetric="downloads"
+                        selectedTrafficSources={selectedSources}
                       />
                     </PremiumCardContent>
                   </PremiumCard>

--- a/src/utils/executiveTrafficSourceGroups.ts
+++ b/src/utils/executiveTrafficSourceGroups.ts
@@ -1,0 +1,16 @@
+import { aggregateTrafficSources } from './trafficSourceGroups';
+
+export const executiveTrafficSources = [
+  'App Store Search',
+  'App Store Browse',
+  'Apple Search Ads',
+  'App Referrer',
+  'Web Referrer'
+] as const;
+
+export const executiveTrafficSourceGroups: Record<string, string[]> = {
+  organic: ['App Store Search', 'App Store Browse'],
+  paid: ['Apple Search Ads', 'App Referrer', 'Web Referrer'],
+};
+
+export { aggregateTrafficSources };


### PR DESCRIPTION
## Summary
- add executive-specific traffic source groups
- enable multi-select for individual sources on executive dashboard
- filter time series chart to show selected traffic sources
