### PR TITLE
feat: add derived KPI framework

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -35,3 +35,10 @@ export { keywordDiscoveryService } from '../services/keyword-discovery.service';
 
 // Add debounced filters hook
 export { useDebouncedFilters } from './useDebouncedFilters';
+
+// Derived KPI framework hooks
+export {
+  useDerivedKPIs,
+  getDerivedKPICategories,
+  validateDerivedKPIDependencies
+} from './useDerivedKPIs';

--- a/src/hooks/useDerivedKPIs.ts
+++ b/src/hooks/useDerivedKPIs.ts
@@ -1,0 +1,75 @@
+import { useMemo } from 'react';
+import type { TrafficSource } from './useMockAsoData';
+import {
+  DERIVED_KPI_REGISTRY,
+  DerivedKPIDefinition
+} from '@/utils/derivedKPIRegistry';
+import {
+  DerivedKPICalculator,
+  TrafficSourceData,
+  DerivedKPIResult
+} from '@/utils/derivedKPICalculator';
+import { executiveTrafficSourceGroups } from '@/utils/executiveTrafficSourceGroups';
+
+export function useDerivedKPIs(
+  sourceData: TrafficSource[] = []
+): DerivedKPIResult[] {
+  return useMemo(() => {
+    const base: TrafficSourceData[] = sourceData.map((src) => ({
+      id: src.name,
+      impressions: src.metrics.impressions.value,
+      downloads: src.metrics.downloads.value,
+      product_page_views: src.metrics.product_page_views.value,
+    }));
+
+    const grouped: TrafficSourceData[] = Object.entries(
+      executiveTrafficSourceGroups
+    ).map(([groupId, members]) => {
+      const aggregate = members.reduce(
+        (acc, id) => {
+          const match = base.find((s) => s.id === id);
+          if (match) {
+            acc.impressions += match.impressions;
+            acc.downloads += match.downloads;
+            acc.product_page_views += match.product_page_views;
+          }
+          return acc;
+        },
+        { impressions: 0, downloads: 0, product_page_views: 0 }
+      );
+      return { id: groupId, ...aggregate };
+    });
+
+    const prepared = [...base, ...grouped];
+
+    return Object.values(DERIVED_KPI_REGISTRY).map((def) =>
+      DerivedKPICalculator.calculate(def, prepared)
+    );
+  }, [sourceData]);
+}
+
+export function getDerivedKPICategories(): Record<
+  string,
+  DerivedKPIDefinition[]
+> {
+  return Object.values(DERIVED_KPI_REGISTRY).reduce(
+    (acc, def) => {
+      (acc[def.category] ||= []).push(def);
+      return acc;
+    },
+    {} as Record<string, DerivedKPIDefinition[]>
+  );
+}
+
+export function validateDerivedKPIDependencies(
+  availableSources: string[]
+): Record<string, boolean> {
+  const result: Record<string, boolean> = {};
+  Object.values(DERIVED_KPI_REGISTRY).forEach((def) => {
+    result[def.id] = DerivedKPICalculator.validateDependencies(
+      def,
+      availableSources
+    );
+  });
+  return result;
+}

--- a/src/utils/derivedKPICalculator.ts
+++ b/src/utils/derivedKPICalculator.ts
@@ -1,0 +1,109 @@
+import type { DerivedKPIDefinition, EdgeCaseRule } from './derivedKPIRegistry';
+
+export interface TrafficSourceData {
+  id: string;
+  impressions: number;
+  downloads: number;
+  product_page_views: number;
+}
+
+export interface DerivedKPIResult {
+  id: string;
+  name: string;
+  metrics: {
+    impressions?: number;
+    downloads?: number;
+    product_page_views?: number;
+  };
+}
+
+export class DerivedKPICalculator {
+  static calculate(
+    kpiDefinition: DerivedKPIDefinition,
+    sourceData: TrafficSourceData[]
+  ): DerivedKPIResult {
+    const dataMap: Record<string, TrafficSourceData> = sourceData.reduce(
+      (acc, item) => {
+        acc[item.id] = item;
+        return acc;
+      },
+      {} as Record<string, TrafficSourceData>
+    );
+
+    const depNames = kpiDefinition.dependencies;
+
+    const result: DerivedKPIResult = {
+      id: kpiDefinition.id,
+      name: kpiDefinition.name,
+      metrics: {}
+    };
+
+    (['impressions', 'downloads', 'product_page_views'] as const).forEach(
+      (metric) => {
+        const formula = kpiDefinition.calculations[metric];
+        if (!formula) return;
+        try {
+          const fn = new Function(
+            ...depNames,
+            `return ${formula};`
+          ) as (...args: TrafficSourceData[]) => number;
+          const args = depNames.map(
+            (dep) => dataMap[dep] || { id: dep, impressions: 0, downloads: 0, product_page_views: 0 }
+          );
+          let value = fn(...args);
+          if (!isFinite(value)) value = 0;
+          const processed = this.handleEdgeCases(
+            value,
+            kpiDefinition.edgeCaseHandling
+          );
+          if (processed !== null && !isNaN(processed)) {
+            result.metrics[metric] = processed;
+          }
+        } catch {
+          // On parsing or execution errors, omit the metric
+        }
+      }
+    );
+
+    return result;
+  }
+
+  static validateDependencies(
+    kpiDefinition: DerivedKPIDefinition,
+    availableSources: string[]
+  ): boolean {
+    return kpiDefinition.dependencies.every((dep) =>
+      availableSources.includes(dep)
+    );
+  }
+
+  static handleEdgeCases(
+    result: number,
+    rules: EdgeCaseRule[] = []
+  ): number | null {
+    for (const rule of rules) {
+      let conditionMet = false;
+      try {
+        const fn = new Function('result', `return ${rule.condition};`) as (
+          r: number
+        ) => boolean;
+        conditionMet = fn(result);
+      } catch {
+        conditionMet = false;
+      }
+      if (conditionMet) {
+        switch (rule.action) {
+          case 'set_zero':
+            return 0;
+          case 'use_fallback':
+            return rule.fallbackValue ?? 0;
+          case 'skip':
+            return null;
+          default:
+            break;
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/src/utils/derivedKPIRegistry.ts
+++ b/src/utils/derivedKPIRegistry.ts
@@ -1,0 +1,21 @@
+export interface EdgeCaseRule {
+  condition: string;
+  action: 'set_zero' | 'use_fallback' | 'skip';
+  fallbackValue?: number;
+}
+
+export interface DerivedKPIDefinition {
+  id: string;
+  name: string;
+  description: string;
+  calculations: {
+    impressions?: string;
+    downloads?: string;
+    product_page_views?: string;
+  };
+  dependencies: string[];
+  category: 'organic' | 'paid' | 'efficiency' | 'conversion';
+  edgeCaseHandling: EdgeCaseRule[];
+}
+
+export const DERIVED_KPI_REGISTRY: Record<string, DerivedKPIDefinition> = {};


### PR DESCRIPTION
## Summary
- scaffold derived KPI registry and calculation engine
- add hook and utilities for computing derived KPIs in Executive Dashboard
- re-export new hooks for easy access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 600 problems (549 errors, 51 warnings))*
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_689c7b8073d08326b010f31a768f1842