### PR TITLE
Show traffic source CVR cards by default

### DIFF
--- a/src/components/TrafficSourceConversionCard.tsx
+++ b/src/components/TrafficSourceConversionCard.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import DeltaIndicator from '@/components/ui/DeltaIndicator';
+import { getTrafficSourceColor } from '@/utils/trafficSourceColors';
+import type { TrafficSource } from '@/hooks/useMockAsoData';
+
+interface Props {
+  source: TrafficSource;
+}
+
+const formatNumber = (num: number): string => num.toLocaleString();
+
+const calculateCVR = (impressions: number, downloads: number, views: number): number => {
+  if (views > 0) return (downloads / views) * 100;
+  if (impressions > 0) return (downloads / impressions) * 100;
+  return 0;
+};
+
+export const TrafficSourceConversionCard: React.FC<Props> = ({ source }) => {
+  const impressions = source.metrics.impressions.value;
+  const downloads = source.metrics.downloads.value;
+  const views = source.metrics.product_page_views.value;
+  const cvr = calculateCVR(impressions, downloads, views);
+  const delta = views > 0 ? source.metrics.product_page_cvr.delta : source.metrics.impressions_cvr.delta;
+  const cardColor = getTrafficSourceColor(source.name);
+
+  return (
+    <Card
+      className="bg-zinc-900 border border-zinc-700 rounded-md shadow-md"
+      style={{ borderLeft: `4px solid ${cardColor}` }}
+    >
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-gray-100">{source.name}</h3>
+          <DeltaIndicator value={delta} />
+        </div>
+        <div className="mt-2 text-2xl font-bold text-gray-100">
+          {cvr.toFixed(1)}%
+        </div>
+        <div className="text-xs text-gray-400">Conversion Rate</div>
+        <div className="mt-2 text-xs text-gray-400">
+          {formatNumber(impressions)} impressions<br />
+          {formatNumber(downloads)} downloads
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TrafficSourceConversionCard;
+

--- a/src/pages/conversion-analysis.tsx
+++ b/src/pages/conversion-analysis.tsx
@@ -5,6 +5,7 @@ import KpiCard from "../components/KpiCard";
 import TimeSeriesChart from "../components/TimeSeriesChart";
 import { TrafficSourceSelect } from "../components/Filters";
 import ConversionRateByTrafficSourceChart from "../components/ConversionRateByTrafficSourceChart";
+import TrafficSourceConversionCard from "../components/TrafficSourceConversionCard";
 import { MainLayout } from '@/layouts';
 import { ContextualInsightsSidebar } from '@/components/AiInsightsPanel/ContextualInsightsSidebar';
 import { Button } from '@/components/ui/button';
@@ -158,20 +159,15 @@ const ConversionAnalysisPage: React.FC = () => {
             <section className="mt-8">
               <h2 className="text-xl font-semibold mb-4">By Traffic Source</h2>
 
-              {selectedSources.length === 0 ? (
+              {filteredSources.length === 0 ? (
                 <div className="bg-zinc-800 p-8 rounded-md text-center">
-                  <p className="text-gray-400">No traffic sources selected. Please select at least one source to view data.</p>
+                  <p className="text-gray-400">No traffic source data available.</p>
                 </div>
               ) : (
                 <>
-                   <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-8">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-8">
                     {filteredSources.map((source) => (
-                      <KpiCard
-                        key={source.name}
-                        title={source.name}
-                        value={source.value || 0}
-                        delta={source.delta || 0}
-                      />
+                      <TrafficSourceConversionCard key={source.name} source={source} />
                     ))}
                   </div>
 


### PR DESCRIPTION
## Summary
- add traffic source conversion card to display CVR percentages with supporting metrics
- show traffic source cards by default using conversion data

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c9ce34ef88326b12c62e357c1fabb