### PR TITLE
feat: add expandable AI insights sidebar

### DIFF
--- a/src/components/AiInsightsPanel/ContextualInsightsSidebar.tsx
+++ b/src/components/AiInsightsPanel/ContextualInsightsSidebar.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import { ChevronDown, ChevronRight, Sparkles, TrendingUp, AlertTriangle } from 'lucide-react';
+import { ChevronDown, ChevronRight, Sparkles, TrendingUp, AlertTriangle, ChevronsLeft, ChevronsRight } from 'lucide-react';
 import { CollapsedSidebar } from './CollapsedSidebar';
 import { useEnhancedAsoInsights } from '@/hooks/useEnhancedAsoInsights';
 import { useAsoData } from '@/context/AsoDataContext';
@@ -14,68 +14,70 @@ import { useConversationalChat } from '@/hooks/useConversationalChat';
 import type { MetricsData, FilterContext } from '@/types/aso';
 import { useTheme } from '@/hooks/useTheme';
 
+export type SidebarState = 'collapsed' | 'normal' | 'expanded';
+
 interface ContextualInsightsSidebarProps {
   metricsData?: any;
   organizationId: string;
-  isExpanded?: boolean;
-  onToggleExpanded?: (expanded: boolean) => void;
+  state?: SidebarState;
+  onStateChange?: (state: SidebarState) => void;
 }
 
 export const ContextualInsightsSidebar: React.FC<ContextualInsightsSidebarProps> = ({
   metricsData,
   organizationId,
-  isExpanded = true,
-  onToggleExpanded
+  state = 'normal',
+  onStateChange
 }) => {
   const queryClient = useQueryClient();
   const { filters } = useAsoData();
   const [isListExpanded, setIsListExpanded] = useState(false);
-  const [internalExpanded, setInternalExpanded] = useState(true);
-  const expanded = onToggleExpanded ? isExpanded : internalExpanded;
-  const setExpanded = onToggleExpanded || setInternalExpanded;
+  const [internalState, setInternalState] = useState<SidebarState>('normal');
+  const sidebarState = onStateChange ? state : internalState;
+  const setSidebarState = onStateChange || setInternalState;
   const [isMobile, setIsMobile] = useState(false);
   // Initialize theme to ensure theme state is active
   useTheme();
 
   useEffect(() => {
-    const saved = localStorage.getItem(`ai-sidebar-expanded-${organizationId}`);
-    if (saved !== null && !onToggleExpanded) {
-      setInternalExpanded(JSON.parse(saved));
+    const saved = localStorage.getItem(`ai-sidebar-state-${organizationId}`);
+    if (saved !== null && !onStateChange) {
+      setInternalState(saved as SidebarState);
     }
-  }, [organizationId, onToggleExpanded]);
+  }, [organizationId, onStateChange]);
 
   useEffect(() => {
-    if (!onToggleExpanded) {
-      localStorage.setItem(`ai-sidebar-expanded-${organizationId}`, JSON.stringify(internalExpanded));
+    if (!onStateChange) {
+      localStorage.setItem(`ai-sidebar-state-${organizationId}`, internalState);
     }
-  }, [internalExpanded, organizationId, onToggleExpanded]);
+  }, [internalState, organizationId, onStateChange]);
 
   useEffect(() => {
     const checkMobile = () => {
       const mobile = window.innerWidth < 768;
       setIsMobile(mobile);
-      if (mobile && !onToggleExpanded) {
-        setInternalExpanded(false);
+      if (mobile && !onStateChange) {
+        setInternalState('collapsed');
       }
     };
     checkMobile();
     window.addEventListener('resize', checkMobile);
     return () => window.removeEventListener('resize', checkMobile);
-  }, [onToggleExpanded]);
+  }, [onStateChange]);
 
   useEffect(() => {
     const handleKeyboard = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === '\\') {
         e.preventDefault();
-        setExpanded(!expanded);
+        setSidebarState(sidebarState === 'collapsed' ? 'normal' : 'collapsed');
       }
-      if (e.key === 'Escape' && isMobile && expanded) {
-        setExpanded(false);
+      if (e.key === 'Escape' && isMobile && sidebarState !== 'collapsed') {
+        setSidebarState('collapsed');
       }
     };
     document.addEventListener('keydown', handleKeyboard);
     return () => document.removeEventListener('keydown', handleKeyboard);
-  }, [expanded, isMobile, setExpanded]);
+  }, [sidebarState, isMobile, setSidebarState]);
 
   const getInsightFreshness = (insightCreatedAt: string, currentFilters: any) => {
     if (!insightCreatedAt) return { status: 'unknown', message: 'No timestamp' };
@@ -173,16 +175,32 @@ useEffect(() => {
             <Sparkles className="w-5 h-5 text-purple-600" />
             <h3 className="font-semibold text-foreground">AI Insights</h3>
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setExpanded(false)}
-            className="p-1 hover:bg-muted"
-            title="Collapse sidebar (Ctrl+\\)"
-            aria-label="Collapse AI insights sidebar"
-          >
-            <ChevronRight className="w-4 h-4 text-muted-foreground" />
-          </Button>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSidebarState(sidebarState === 'expanded' ? 'normal' : 'expanded')}
+              className="p-1 hover:bg-muted"
+              title={sidebarState === 'expanded' ? 'Shrink sidebar' : 'Expand sidebar'}
+              aria-label={sidebarState === 'expanded' ? 'Shrink AI insights sidebar' : 'Expand AI insights sidebar'}
+            >
+              {sidebarState === 'expanded' ? (
+                <ChevronsRight className="w-4 h-4 text-muted-foreground" />
+              ) : (
+                <ChevronsLeft className="w-4 h-4 text-muted-foreground" />
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSidebarState('collapsed')}
+              className="p-1 hover:bg-muted"
+              title="Collapse sidebar (Ctrl+\\)"
+              aria-label="Collapse AI insights sidebar"
+            >
+              <ChevronRight className="w-4 h-4 text-muted-foreground" />
+            </Button>
+          </div>
         </div>
         <p className="text-xs text-muted-foreground">
           Analyzing {getFilterSummary()}
@@ -332,17 +350,17 @@ useEffect(() => {
     </>
   );
 
-  if (!expanded) {
+  if (sidebarState === 'collapsed') {
     return (
       <>
         <CollapsedSidebar
-          onExpand={() => setExpanded(true)}
+          onExpand={() => setSidebarState('normal')}
           {...statusIndicators}
           className={`transition-all duration-300 ease-in-out ${isMobile ? 'w-12' : 'w-15'}`}
         />
         {isMobile && (
           <Button
-            onClick={() => setExpanded(true)}
+            onClick={() => setSidebarState('normal')}
             className="fixed bottom-6 right-6 w-12 h-12 rounded-full shadow-lg z-20"
             title="Open AI Insights"
             aria-label="Open AI Insights"
@@ -354,12 +372,12 @@ useEffect(() => {
     );
   }
 
-  if (expanded && isMobile) {
+  if (isMobile) {
     return (
       <>
         <div
           className="fixed inset-0 bg-black/50 z-15 mobile-overlay"
-          onClick={() => setExpanded(false)}
+          onClick={() => setSidebarState('collapsed')}
         />
         <div className="fixed inset-y-0 right-0 w-full max-w-sm z-20 transition-transform duration-300 sidebar-container" role="complementary" aria-label="AI Insights Panel">
           {sidebarContent}
@@ -368,8 +386,10 @@ useEffect(() => {
     );
   }
 
+  const widthClass = sidebarState === 'expanded' ? 'w-[60vw] max-w-3xl' : 'w-80';
+
   return (
-    <div className="w-80 h-screen bg-background/50 border-l border-border flex flex-col transition-all duration-300 ease-in-out sidebar-container" role="complementary" aria-label="AI Insights Panel">
+    <div className={`${widthClass} h-screen bg-background/50 border-l border-border flex flex-col transition-all duration-300 ease-in-out sidebar-container`} role="complementary" aria-label="AI Insights Panel">
       {sidebarContent}
     </div>
   );

--- a/src/components/AiInsightsPanel/index.ts
+++ b/src/components/AiInsightsPanel/index.ts
@@ -6,4 +6,5 @@ export { InsightRequestCards } from './InsightRequestCards';
 export { InsightResults } from './InsightResults';
 export { EnhancedInsightCard } from './EnhancedInsightCard';
 export { default as ContextualInsightsSidebar } from './ContextualInsightsSidebar';
+export type { SidebarState } from './ContextualInsightsSidebar';
 export { SidebarToggle } from './SidebarToggle';

--- a/src/pages/conversion-analysis.tsx
+++ b/src/pages/conversion-analysis.tsx
@@ -9,7 +9,7 @@ import ConversionRateChart from "../components/ConversionRateChart";
 import TrafficSourceCVRCard from "../components/TrafficSourceCVRCard";
 import { processTrafficSourceCVR, CVRType } from "../utils/processTrafficSourceCVR";
 import { MainLayout } from '@/layouts';
-import { ContextualInsightsSidebar } from '@/components/AiInsightsPanel/ContextualInsightsSidebar';
+import { ContextualInsightsSidebar, SidebarState } from '@/components/AiInsightsPanel/ContextualInsightsSidebar';
 import { Button } from '@/components/ui/button';
 import { Sparkles } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
@@ -21,6 +21,7 @@ const ConversionAnalysisPage: React.FC = () => {
   const [organizationId, setOrganizationId] = useState('');
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
+  const [sidebarState, setSidebarState] = useState<SidebarState>('normal');
   
   const [selectedSources, setSelectedSources] = useState<string[]>([]);
   const [cvrType, setCvrType] = useState<CVRType>('impression');
@@ -75,18 +76,33 @@ const ConversionAnalysisPage: React.FC = () => {
   }, [user]);
 
   useEffect(() => {
+    if (!organizationId) return;
+    const saved = localStorage.getItem(`ai-sidebar-state-${organizationId}`);
+    if (saved) {
+      setSidebarState(saved as SidebarState);
+    }
+  }, [organizationId]);
+
+  useEffect(() => {
     const checkMobile = () => setIsMobile(window.innerWidth < 768);
     checkMobile();
     window.addEventListener('resize', checkMobile);
     return () => window.removeEventListener('resize', checkMobile);
   }, []);
 
+  const handleSidebarStateChange = (state: SidebarState) => {
+    setSidebarState(state);
+    if (organizationId) {
+      localStorage.setItem(`ai-sidebar-state-${organizationId}`, state);
+    }
+  };
+
   // Display a loading state when data is being fetched
   if (loading || !data) {
     return (
       <MainLayout>
         <div className="flex min-h-screen">
-          <div className={`flex-1 ${!isMobile ? 'pr-80' : ''}`}> 
+          <div className={`flex-1 ${!isMobile ? (sidebarState === 'collapsed' ? 'pr-15' : sidebarState === 'expanded' ? 'pr-[60vw]' : 'pr-80') : ''}`}>
             <div className="p-6 flex flex-col space-y-6">
               {isMobile && (
                 <Button
@@ -125,6 +141,8 @@ const ConversionAnalysisPage: React.FC = () => {
             <ContextualInsightsSidebar
               metricsData={data}
               organizationId={organizationId}
+              state={sidebarState}
+              onStateChange={handleSidebarStateChange}
             />
           </div>
           {isMobile && isMobileSidebarOpen && (
@@ -141,7 +159,7 @@ const ConversionAnalysisPage: React.FC = () => {
   return (
     <MainLayout>
       <div className="flex min-h-screen">
-        <div className={`flex-1 ${!isMobile ? 'pr-80' : ''}`}> 
+        <div className={`flex-1 ${!isMobile ? (sidebarState === 'collapsed' ? 'pr-15' : sidebarState === 'expanded' ? 'pr-[60vw]' : 'pr-80') : ''}`}>
           <div className="p-6 flex flex-col space-y-6">
             {isMobile && (
               <Button
@@ -231,6 +249,8 @@ const ConversionAnalysisPage: React.FC = () => {
           <ContextualInsightsSidebar
             metricsData={data}
             organizationId={organizationId}
+            state={sidebarState}
+            onStateChange={handleSidebarStateChange}
           />
         </div>
         {isMobile && isMobileSidebarOpen && (

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from "react-router-dom";
 import { BrandedLoadingSpinner } from "@/components/ui/LoadingSkeleton";
 import { MetricSelector } from '@/components/charts/MetricSelector';
 import { MainLayout } from '@/layouts';
-import { ContextualInsightsSidebar } from '@/components/AiInsightsPanel/ContextualInsightsSidebar';
+import { ContextualInsightsSidebar, SidebarState } from '@/components/AiInsightsPanel/ContextualInsightsSidebar';
 import { useAuth } from '@/context/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { KPISelector } from '../components/KPISelector';
@@ -38,7 +38,7 @@ const Dashboard: React.FC = () => {
   } = useAsoData();
   const { user } = useAuth();
   const [organizationId, setOrganizationId] = useState('');
-  const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
+  const [sidebarState, setSidebarState] = useState<SidebarState>('normal');
 
   useEffect(() => {
     const fetchOrganizationId = async () => {
@@ -52,6 +52,14 @@ const Dashboard: React.FC = () => {
     };
     fetchOrganizationId();
   }, [user]);
+
+  useEffect(() => {
+    if (!organizationId) return;
+    const saved = localStorage.getItem(`ai-sidebar-state-${organizationId}`);
+    if (saved) {
+      setSidebarState(saved as SidebarState);
+    }
+  }, [organizationId]);
 
 
   // Enhanced traffic source filter change handler with validation
@@ -78,6 +86,13 @@ const Dashboard: React.FC = () => {
 
   const handleKPIChange = (value: string) => {
     setSelectedKPI(value);
+  };
+
+  const handleSidebarStateChange = (state: SidebarState) => {
+    setSidebarState(state);
+    if (organizationId) {
+      localStorage.setItem(`ai-sidebar-state-${organizationId}`, state);
+    }
   };
 
 
@@ -163,7 +178,7 @@ const Dashboard: React.FC = () => {
     <MainLayout>
       <div className="flex min-h-screen">
         {/* Main Content - Responsive padding */}
-        <div className={`flex-1 transition-all duration-300 ease-in-out ${isSidebarExpanded ? 'pr-80' : 'pr-15'} main-content`}>
+        <div className={`flex-1 transition-all duration-300 ease-in-out ${sidebarState === 'collapsed' ? 'pr-15' : sidebarState === 'expanded' ? 'pr-[60vw]' : 'pr-80'} main-content`}>
           <div className="space-y-6 p-6">
       <div className="flex justify-between items-start mb-6">
         <div className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 ${gridCols} gap-6 flex-1`}>
@@ -328,8 +343,8 @@ const Dashboard: React.FC = () => {
             <ContextualInsightsSidebar
               metricsData={data}
               organizationId={organizationId}
-              isExpanded={isSidebarExpanded}
-              onToggleExpanded={setIsSidebarExpanded}
+              state={sidebarState}
+              onStateChange={handleSidebarStateChange}
             />
           ) : (
             <div className="w-80 h-screen bg-background/50 border-l border-border flex items-center justify-center">

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -28,7 +28,7 @@ import {
   StatusIndicator
 } from "@/components/ui/premium";
 import { MainLayout } from '@/layouts';
-import { ContextualInsightsSidebar } from '@/components/AiInsightsPanel/ContextualInsightsSidebar';
+import { ContextualInsightsSidebar, SidebarState } from '@/components/AiInsightsPanel/ContextualInsightsSidebar';
 import { Button } from '@/components/ui/button';
 import { Sparkles } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
@@ -40,6 +40,7 @@ const OverviewPage: React.FC = () => {
   const [organizationId, setOrganizationId] = useState('');
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
+  const [sidebarState, setSidebarState] = useState<SidebarState>('normal');
   const [trafficSourceView, setTrafficSourceView] = useState<string>('all');
   const [selectedSources, setSelectedSources] = useState<string[]>([...executiveTrafficSources]);
 
@@ -57,11 +58,26 @@ const OverviewPage: React.FC = () => {
   }, [user]);
 
   useEffect(() => {
+    if (!organizationId) return;
+    const saved = localStorage.getItem(`ai-sidebar-state-${organizationId}`);
+    if (saved) {
+      setSidebarState(saved as SidebarState);
+    }
+  }, [organizationId]);
+
+  useEffect(() => {
     const checkMobile = () => setIsMobile(window.innerWidth < 768);
     checkMobile();
     window.addEventListener('resize', checkMobile);
     return () => window.removeEventListener('resize', checkMobile);
   }, []);
+
+  const handleSidebarStateChange = (state: SidebarState) => {
+    setSidebarState(state);
+    if (organizationId) {
+      localStorage.setItem(`ai-sidebar-state-${organizationId}`, state);
+    }
+  };
 
   const trafficSourceTimeseries = useMemo(
     () => data?.trafficSourceTimeseriesData || [],
@@ -121,7 +137,7 @@ const OverviewPage: React.FC = () => {
     return (
       <MainLayout>
         <div className="flex min-h-screen">
-          <div className={`flex-1 ${!isMobile ? 'pr-80' : ''}`}>
+          <div className={`flex-1 ${!isMobile ? (sidebarState === 'collapsed' ? 'pr-15' : sidebarState === 'expanded' ? 'pr-[60vw]' : 'pr-80') : ''}`}>
             <LayoutSection spacing="md" className="p-6">
               {isMobile && (
                 <Button
@@ -160,6 +176,8 @@ const OverviewPage: React.FC = () => {
             <ContextualInsightsSidebar
               metricsData={data}
               organizationId={organizationId}
+              state={sidebarState}
+              onStateChange={handleSidebarStateChange}
             />
           </div>
           {isMobile && isMobileSidebarOpen && (
@@ -249,7 +267,7 @@ const OverviewPage: React.FC = () => {
   return (
     <MainLayout>
       <div className="flex min-h-screen">
-        <div className={`flex-1 ${!isMobile ? 'pr-80' : ''}`}> 
+        <div className={`flex-1 ${!isMobile ? (sidebarState === 'collapsed' ? 'pr-15' : sidebarState === 'expanded' ? 'pr-[60vw]' : 'pr-80') : ''}`}>
           <div className="p-6">
             {isMobile && (
               <Button
@@ -408,6 +426,8 @@ const OverviewPage: React.FC = () => {
           <ContextualInsightsSidebar
             metricsData={data}
             organizationId={organizationId}
+            state={sidebarState}
+            onStateChange={handleSidebarStateChange}
           />
         </div>
         {isMobile && isMobileSidebarOpen && (


### PR DESCRIPTION
## Summary
- add `SidebarState` with collapsed, normal, expanded modes for AI insights
- persist sidebar state with localStorage and expose expand/shrink controls
- adjust dashboard and other pages to pad content and pass sidebar state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 554 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ccde805988326b74755f02c8ea6d1