### PR TITLE
Align executive KPI card styling with analytics cards

### DIFF
--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -307,26 +307,31 @@ const OverviewPage: React.FC = () => {
                       title="Impressions"
                       value={impressionsValue}
                       delta={impressionsDelta}
+                      className="bg-zinc-800 border border-zinc-700"
                     />
                     <KpiCard
                       title="Downloads"
                       value={downloadsValue}
                       delta={downloadsDelta}
+                      className="bg-zinc-800 border border-zinc-700"
                     />
                     <KpiCard
                       title="Product Page Views"
                       value={pageViewsValue}
                       delta={pageViewsDelta}
+                      className="bg-zinc-800 border border-zinc-700"
                     />
                     <KpiCard
                       title="True Search Impressions"
                       value={trueSearchImpressionsValue}
                       delta={trueSearchImpressionsDelta}
+                      className="bg-zinc-800 border border-zinc-700"
                     />
                     <KpiCard
                       title="True Search Downloads"
                       value={trueSearchDownloadsValue}
                       delta={trueSearchDownloadsDelta}
+                      className="bg-zinc-800 border border-zinc-700"
                     />
                   </div>
 


### PR DESCRIPTION
## Summary
- apply analytics card background and border styling to executive dashboard KPI cards for consistent visuals

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 605 problems)

------
https://chatgpt.com/codex/tasks/task_e_689cd29bc17c83269b03af6cf2d2cc2b