### PR TITLE
Add conversion benchmark comparison with industry data

### DIFF
--- a/src/components/BenchmarkIndicator.tsx
+++ b/src/components/BenchmarkIndicator.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface BenchmarkIndicatorProps {
+  clientValue: number;
+  benchmark: number;
+}
+
+const BenchmarkIndicator: React.FC<BenchmarkIndicatorProps> = ({ clientValue, benchmark }) => {
+  const performance = clientValue > benchmark ? 'above' : clientValue < benchmark ? 'below' : 'at';
+  const color =
+    performance === 'above'
+      ? 'text-green-600'
+      : performance === 'below'
+      ? 'text-red-600'
+      : 'text-yellow-600';
+  const symbol = performance === 'above' ? '↗' : performance === 'below' ? '↘' : '→';
+  const text = performance === 'above' ? 'Above' : performance === 'below' ? 'Below' : 'At';
+
+  return (
+    <div className="text-xs mt-1">
+      <span className="text-muted-foreground">Industry: {benchmark}%</span>
+      <span className={`ml-2 ${color}`}>
+        {symbol} {text} benchmark
+      </span>
+    </div>
+  );
+};
+
+export default BenchmarkIndicator;

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+interface CategorySelectorProps {
+  selectedCategory: string;
+  onCategoryChange: (value: string) => void;
+  availableCategories: string[];
+}
+
+const CategorySelector: React.FC<CategorySelectorProps> = ({
+  selectedCategory,
+  onCategoryChange,
+  availableCategories,
+}) => (
+  <Select value={selectedCategory} onValueChange={onCategoryChange}>
+    <SelectTrigger className="w-48 h-8 bg-zinc-800 border-zinc-700 text-foreground">
+      <SelectValue placeholder="Select app category" />
+    </SelectTrigger>
+    <SelectContent className="bg-zinc-800 border-zinc-700">
+      {availableCategories.map((category) => (
+        <SelectItem
+          key={category}
+          value={category}
+          className="text-foreground hover:bg-zinc-700"
+        >
+          {category}
+        </SelectItem>
+      ))}
+    </SelectContent>
+  </Select>
+);
+
+export default CategorySelector;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,6 +7,7 @@ export * from './useCopilotChat';
 export * from './useBigQueryData';
 export * from './useAsoDataWithFallback';
 export * from './useFeaturingValidation';
+export { useBenchmarkData } from './useBenchmarkData';
 export { useConversationalChat } from './useConversationalChat';
 
 // Re-export workflow context for convenience

--- a/src/hooks/useBenchmarkData.ts
+++ b/src/hooks/useBenchmarkData.ts
@@ -1,0 +1,105 @@
+import { useEffect, useState, useCallback } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+interface BenchmarkMetrics {
+  impressions_to_page_views: number;
+  page_views_to_installs: number;
+  impressions_to_installs: number;
+}
+
+interface BenchmarkComparison {
+  category: string;
+  benchmarks: BenchmarkMetrics;
+  client_performance?: BenchmarkMetrics;
+  performance_vs_benchmark?: {
+    impressions_to_page_views: 'above' | 'below' | 'at';
+    page_views_to_installs: 'above' | 'below' | 'at';
+    impressions_to_installs: 'above' | 'below' | 'at';
+  };
+}
+
+export const useBenchmarkData = (
+  selectedCategory: string,
+  clientMetrics?: {
+    impressions_to_page_views: number;
+    page_views_to_installs: number;
+  }
+): {
+  data: BenchmarkComparison | null;
+  loading: boolean;
+  error: Error | null;
+  availableCategories: string[];
+} => {
+  const [data, setData] = useState<BenchmarkComparison | null>(null);
+  const [availableCategories, setAvailableCategories] = useState<string[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchCategories = useCallback(async () => {
+    const { data: categories, error } = await supabase
+      .from('conversion_benchmarks')
+      .select('category');
+    if (error) {
+      setError(error);
+      return;
+    }
+    const sorted = categories.map((c) => c.category).sort();
+    setAvailableCategories(sorted);
+  }, []);
+
+  const fetchBenchmark = useCallback(async () => {
+    if (!selectedCategory) return;
+    setLoading(true);
+    const { data: benchmark, error } = await supabase
+      .from('conversion_benchmarks')
+      .select('category, impressions_to_page_views, page_views_to_installs, impressions_to_installs')
+      .eq('category', selectedCategory)
+      .single();
+    if (error) {
+      setError(error);
+      setLoading(false);
+      return;
+    }
+    let client_performance: BenchmarkMetrics | undefined;
+    let performance_vs_benchmark: BenchmarkComparison['performance_vs_benchmark'] | undefined;
+    if (clientMetrics) {
+      const impressions_to_installs =
+        (clientMetrics.impressions_to_page_views * clientMetrics.page_views_to_installs) / 100;
+      client_performance = {
+        impressions_to_page_views: clientMetrics.impressions_to_page_views,
+        page_views_to_installs: clientMetrics.page_views_to_installs,
+        impressions_to_installs,
+      };
+      const compare = (client: number, bench: number) =>
+        client > bench ? 'above' : client < bench ? 'below' : 'at';
+      performance_vs_benchmark = {
+        impressions_to_page_views: compare(client_performance.impressions_to_page_views, benchmark.impressions_to_page_views),
+        page_views_to_installs: compare(client_performance.page_views_to_installs, benchmark.page_views_to_installs),
+        impressions_to_installs: compare(client_performance.impressions_to_installs, benchmark.impressions_to_installs),
+      };
+    }
+    setData({
+      category: benchmark.category,
+      benchmarks: {
+        impressions_to_page_views: benchmark.impressions_to_page_views,
+        page_views_to_installs: benchmark.page_views_to_installs,
+        impressions_to_installs: benchmark.impressions_to_installs,
+      },
+      client_performance,
+      performance_vs_benchmark,
+    });
+    setLoading(false);
+  }, [selectedCategory, clientMetrics]);
+
+  useEffect(() => {
+    fetchCategories();
+  }, [fetchCategories]);
+
+  useEffect(() => {
+    fetchBenchmark();
+  }, [fetchBenchmark]);
+
+  return { data, loading, error, availableCategories };
+};
+
+export default useBenchmarkData;

--- a/src/pages/conversion-analysis.test.tsx
+++ b/src/pages/conversion-analysis.test.tsx
@@ -11,6 +11,15 @@ jest.mock('../context/AsoDataContext', () => ({
   useAsoData: jest.fn(),
 }));
 
+jest.mock('../hooks/useBenchmarkData', () => ({
+  useBenchmarkData: jest.fn().mockReturnValue({
+    data: null,
+    loading: false,
+    error: null,
+    availableCategories: [],
+  }),
+}));
+
 // Mock the layout component to simplify testing
 jest.mock('../layouts', () => ({
   MainLayout: ({ children }: { children: React.ReactNode }) => <div data-testid="main-layout">{children}</div>,
@@ -51,6 +60,16 @@ jest.mock('../components/CVRTypeToggle', () => ({
 // Mock the TrafficSourceSelect component
 jest.mock('../components/Filters', () => ({
   TrafficSourceSelect: () => <div data-testid="traffic-source-select">Traffic Source Select</div>,
+}));
+
+jest.mock('../components/CategorySelector', () => ({
+  __esModule: true,
+  default: () => <div data-testid="category-selector">Category Selector</div>,
+}));
+
+jest.mock('../components/BenchmarkIndicator', () => ({
+  __esModule: true,
+  default: () => <div data-testid="benchmark-indicator">Benchmark Indicator</div>,
 }));
 
 describe('ConversionAnalysisPage', () => {

--- a/src/pages/conversion-analysis.tsx
+++ b/src/pages/conversion-analysis.tsx
@@ -14,6 +14,9 @@ import { Button } from '@/components/ui/button';
 import { Sparkles } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
+import CategorySelector from '@/components/CategorySelector';
+import BenchmarkIndicator from '@/components/BenchmarkIndicator';
+import { useBenchmarkData } from '../hooks/useBenchmarkData';
 
 const ConversionAnalysisPage: React.FC = () => {
   const { data, loading } = useAsoData();
@@ -25,6 +28,7 @@ const ConversionAnalysisPage: React.FC = () => {
   
   const [selectedSources, setSelectedSources] = useState<string[]>([]);
   const [cvrType, setCvrType] = useState<CVRType>('impression');
+  const [selectedCategory, setSelectedCategory] = useState<string>('Photo & Video');
 
   const trafficSources = data?.trafficSources || [];
   const filteredSources = selectedSources.length > 0
@@ -61,6 +65,16 @@ const ConversionAnalysisPage: React.FC = () => {
           : item.appStoreBrowse_product_page_cvr,
     }));
   }, [data?.cvrTimeSeries, cvrType]);
+
+  const { data: benchmarkComparison, availableCategories } = useBenchmarkData(
+    selectedCategory,
+    data
+      ? {
+          impressions_to_page_views: data.summary.impressions_cvr.value,
+          page_views_to_installs: data.summary.product_page_cvr.value,
+        }
+      : undefined
+  );
 
   useEffect(() => {
     const fetchOrganizationId = async () => {
@@ -172,7 +186,14 @@ const ConversionAnalysisPage: React.FC = () => {
                 Insights
               </Button>
             )}
-            <h1 className="text-2xl font-bold">Conversion Analysis</h1>
+            <div className="flex items-center gap-4">
+              <h1 className="text-2xl font-bold">Conversion Analysis</h1>
+              <CategorySelector
+                selectedCategory={selectedCategory}
+                onCategoryChange={setSelectedCategory}
+                availableCategories={availableCategories}
+              />
+            </div>
 
             {/* Cumulative Section */}
             <section>
@@ -185,6 +206,12 @@ const ConversionAnalysisPage: React.FC = () => {
                     delta={data.summary.product_page_cvr.delta}
                     isPercentage
                   />
+                  {benchmarkComparison && (
+                    <BenchmarkIndicator
+                      clientValue={data.summary.product_page_cvr.value}
+                      benchmark={benchmarkComparison.benchmarks.page_views_to_installs}
+                    />
+                  )}
                 </div>
                 <div className="w-64">
                   <KpiCard
@@ -193,6 +220,12 @@ const ConversionAnalysisPage: React.FC = () => {
                     delta={data.summary.impressions_cvr.delta}
                     isPercentage
                   />
+                  {benchmarkComparison && (
+                    <BenchmarkIndicator
+                      clientValue={data.summary.impressions_cvr.value}
+                      benchmark={benchmarkComparison.benchmarks.impressions_to_page_views}
+                    />
+                  )}
                 </div>
               </div>
             </section>

--- a/supabase/migrations/20250808120000_103faa10-34b2-42e6-a872-69f7cc721b6d.sql
+++ b/supabase/migrations/20250808120000_103faa10-34b2-42e6-a872-69f7cc721b6d.sql
@@ -1,0 +1,73 @@
+-- Conversion benchmarks table matching data structure
+CREATE TABLE public.conversion_benchmarks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  category VARCHAR(100) NOT NULL,
+  impressions_to_page_views DECIMAL(5,2),
+  page_views_to_installs DECIMAL(5,2),
+  impressions_to_installs DECIMAL(5,2),
+  data_source VARCHAR(50) DEFAULT 'industry_report_2024',
+  last_updated TIMESTAMP DEFAULT NOW(),
+  created_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(category)
+);
+
+-- Enable RLS
+ALTER TABLE conversion_benchmarks ENABLE ROW LEVEL SECURITY;
+
+-- Public read access (industry benchmarks are not tenant-specific)
+CREATE POLICY benchmark_read_access ON conversion_benchmarks
+  FOR SELECT TO authenticated USING (true);
+
+-- Admin management access
+CREATE POLICY benchmark_admin_access ON conversion_benchmarks
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM user_profiles
+      WHERE id = auth.uid()
+      AND role IN ('super_admin', 'org_admin')
+    )
+  );
+
+-- Insert the benchmark data
+INSERT INTO conversion_benchmarks (category, impressions_to_page_views, page_views_to_installs, impressions_to_installs) VALUES
+('Business', 19.52, 33.95, 6.63),
+('Weather', 16.54, 42.34, 7.00),
+('Utilities', 8.35, 46.78, 3.91),
+('Travel', 45.08, 12.06, 5.44),
+('Sports', 29.14, 11.68, 3.40),
+('Social Networking', 7.07, 27.61, 1.95),
+('Reference', 21.33, 66.23, 14.13),
+('Productivity', 9.96, 44.74, 4.46),
+('Photo & Video', 8.77, 43.43, 3.81),
+('News', 9.42, 34.92, 3.29),
+('Navigation', 14.52, 54.78, 7.95),
+('Music', 10.49, 40.24, 4.22),
+('Lifestyle', 9.57, 36.47, 3.49),
+('Health & Fitness', 16.29, 32.26, 5.26),
+('Games', 25.76, 4.96, 1.28),
+('Finance', 25.84, 20.86, 5.39),
+('Entertainment', 20.88, 6.36, 1.33),
+('Education', 15.61, 20.74, 3.24),
+('Books', 51.40, 6.59, 3.39),
+('Medical', 22.79, 33.82, 7.71),
+('Magazines & Newspapers', 34.42, 4.67, 1.61),
+('Food & Drink', 58.43, 6.77, 3.95),
+('Shopping', 40.95, 12.57, 5.15),
+('Games - Action', 13.57, 7.40, 1.00),
+('Games - Adventure', 10.02, 7.57, 0.76),
+('Games - Casual', 36.61, 4.24, 1.55),
+('Games - Board', 35.25, 1.77, 0.62),
+('Games - Card', 34.89, 7.27, 2.54),
+('Games - Casino', 63.80, 3.85, 2.46),
+('Games - Family', 27.81, 2.38, 0.66),
+('Games - Music', 18.54, 12.44, 2.31),
+('Games - Puzzle', 38.47, 2.91, 1.12),
+('Games - Racing', 13.42, 13.16, 1.77),
+('Games - Role Playing', 25.03, 7.33, 1.84),
+('Games - Simulation', 33.00, 8.49, 2.80),
+('Games - Sports', 16.62, 12.48, 2.08),
+('Games - Strategy', 26.98, 7.14, 1.93),
+('Games - Trivia', 3.65, 45.14, 1.65),
+('Games - Word', 18.48, 18.72, 3.46);
+


### PR DESCRIPTION
## Summary
- add conversion_benchmarks table with RLS policies and seed data
- introduce useBenchmarkData hook and benchmark UI components
- integrate category selector and benchmark indicators into conversion analysis page
