### PR TITLE
feat: add fullscreen chat mode

### DIFF
--- a/src/components/AiInsightsPanel/ConversationalChat.tsx
+++ b/src/components/AiInsightsPanel/ConversationalChat.tsx
@@ -19,6 +19,7 @@ interface ConversationalChatProps {
   organizationId: string;
   onGenerateInsight: (question: string) => Promise<string>;
   isGenerating?: boolean;
+  className?: string;
 }
 
 export const ConversationalChat: React.FC<ConversationalChatProps> = ({
@@ -26,7 +27,8 @@ export const ConversationalChat: React.FC<ConversationalChatProps> = ({
   filterContext,
   organizationId,
   onGenerateInsight,
-  isGenerating = false
+  isGenerating = false,
+  className = 'h-80'
 }) => {
   void organizationId;
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -105,7 +107,7 @@ export const ConversationalChat: React.FC<ConversationalChatProps> = ({
   ];
 
   return (
-    <div className="flex flex-col h-80">
+    <div className={`flex flex-col ${className}`}>
       {/* Chat Header */}
       <CardHeader className="flex-shrink-0 pb-3">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add fullscreen option to AI Insights sidebar
- allow chat panel to stretch in fullscreen
- expose chat container className for flexible sizing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npx eslint src/components/AiInsightsPanel/ContextualInsightsSidebar.tsx src/components/AiInsightsPanel/ConversationalChat.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cdbe26394832682caff846b4b8266