### PR TITLE
feat: add conversion benchmark selector

### DIFF
--- a/src/hooks/useBenchmarkData.ts
+++ b/src/hooks/useBenchmarkData.ts
@@ -1,105 +1,47 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 
-interface BenchmarkMetrics {
+interface BenchmarkData {
+  category: string;
   impressions_to_page_views: number;
   page_views_to_installs: number;
   impressions_to_installs: number;
 }
 
-interface BenchmarkComparison {
-  category: string;
-  benchmarks: BenchmarkMetrics;
-  client_performance?: BenchmarkMetrics;
-  performance_vs_benchmark?: {
-    impressions_to_page_views: 'above' | 'below' | 'at';
-    page_views_to_installs: 'above' | 'below' | 'at';
-    impressions_to_installs: 'above' | 'below' | 'at';
-  };
-}
-
-export const useBenchmarkData = (
-  selectedCategory: string,
-  clientMetrics?: {
-    impressions_to_page_views: number;
-    page_views_to_installs: number;
-  }
-): {
-  data: BenchmarkComparison | null;
-  loading: boolean;
-  error: Error | null;
-  availableCategories: string[];
-} => {
-  const [data, setData] = useState<BenchmarkComparison | null>(null);
+export const useBenchmarkData = (selectedCategory: string) => {
+  const [data, setData] = useState<BenchmarkData | null>(null);
+  const [loading, setLoading] = useState(false);
   const [availableCategories, setAvailableCategories] = useState<string[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [error, setError] = useState<Error | null>(null);
 
-  const fetchCategories = useCallback(async () => {
-    const { data: categories, error } = await supabase
-      .from('conversion_benchmarks')
-      .select('category');
-    if (error) {
-      setError(error);
-      return;
-    }
-    const sorted = categories.map((c) => c.category).sort();
-    setAvailableCategories(sorted);
+  useEffect(() => {
+    const fetchCategories = async () => {
+      const { data: categories } = await supabase
+        .from('conversion_benchmarks')
+        .select('category')
+        .order('category');
+      if (categories) {
+        setAvailableCategories(categories.map((c) => c.category));
+      }
+    };
+    fetchCategories();
   }, []);
 
-  const fetchBenchmark = useCallback(async () => {
+  useEffect(() => {
     if (!selectedCategory) return;
-    setLoading(true);
-    const { data: benchmark, error } = await supabase
-      .from('conversion_benchmarks')
-      .select('category, impressions_to_page_views, page_views_to_installs, impressions_to_installs')
-      .eq('category', selectedCategory)
-      .single();
-    if (error) {
-      setError(error);
+    const fetchBenchmark = async () => {
+      setLoading(true);
+      const { data: benchmark } = await supabase
+        .from('conversion_benchmarks')
+        .select('category, impressions_to_page_views, page_views_to_installs, impressions_to_installs')
+        .eq('category', selectedCategory)
+        .single();
+      setData(benchmark);
       setLoading(false);
-      return;
-    }
-    let client_performance: BenchmarkMetrics | undefined;
-    let performance_vs_benchmark: BenchmarkComparison['performance_vs_benchmark'] | undefined;
-    if (clientMetrics) {
-      const impressions_to_installs =
-        (clientMetrics.impressions_to_page_views * clientMetrics.page_views_to_installs) / 100;
-      client_performance = {
-        impressions_to_page_views: clientMetrics.impressions_to_page_views,
-        page_views_to_installs: clientMetrics.page_views_to_installs,
-        impressions_to_installs,
-      };
-      const compare = (client: number, bench: number) =>
-        client > bench ? 'above' : client < bench ? 'below' : 'at';
-      performance_vs_benchmark = {
-        impressions_to_page_views: compare(client_performance.impressions_to_page_views, benchmark.impressions_to_page_views),
-        page_views_to_installs: compare(client_performance.page_views_to_installs, benchmark.page_views_to_installs),
-        impressions_to_installs: compare(client_performance.impressions_to_installs, benchmark.impressions_to_installs),
-      };
-    }
-    setData({
-      category: benchmark.category,
-      benchmarks: {
-        impressions_to_page_views: benchmark.impressions_to_page_views,
-        page_views_to_installs: benchmark.page_views_to_installs,
-        impressions_to_installs: benchmark.impressions_to_installs,
-      },
-      client_performance,
-      performance_vs_benchmark,
-    });
-    setLoading(false);
-  }, [selectedCategory, clientMetrics]);
-
-  useEffect(() => {
-    fetchCategories();
-  }, [fetchCategories]);
-
-  useEffect(() => {
+    };
     fetchBenchmark();
-  }, [fetchBenchmark]);
+  }, [selectedCategory]);
 
-  return { data, loading, error, availableCategories };
+  return { data, loading, availableCategories };
 };
 
 export default useBenchmarkData;

--- a/src/pages/conversion-analysis.test.tsx
+++ b/src/pages/conversion-analysis.test.tsx
@@ -15,7 +15,6 @@ jest.mock('../hooks/useBenchmarkData', () => ({
   useBenchmarkData: jest.fn().mockReturnValue({
     data: null,
     loading: false,
-    error: null,
     availableCategories: [],
   }),
 }));

--- a/src/pages/conversion-analysis.tsx
+++ b/src/pages/conversion-analysis.tsx
@@ -66,14 +66,8 @@ const ConversionAnalysisPage: React.FC = () => {
     }));
   }, [data?.cvrTimeSeries, cvrType]);
 
-  const { data: benchmarkComparison, availableCategories } = useBenchmarkData(
-    selectedCategory,
-    data
-      ? {
-          impressions_to_page_views: data.summary.impressions_cvr.value,
-          page_views_to_installs: data.summary.product_page_cvr.value,
-        }
-      : undefined
+  const { data: benchmarkData, availableCategories } = useBenchmarkData(
+    selectedCategory
   );
 
   useEffect(() => {
@@ -206,10 +200,10 @@ const ConversionAnalysisPage: React.FC = () => {
                     delta={data.summary.product_page_cvr.delta}
                     isPercentage
                   />
-                  {benchmarkComparison && (
+                  {benchmarkData && (
                     <BenchmarkIndicator
                       clientValue={data.summary.product_page_cvr.value}
-                      benchmark={benchmarkComparison.benchmarks.page_views_to_installs}
+                      benchmark={benchmarkData.page_views_to_installs}
                     />
                   )}
                 </div>
@@ -220,10 +214,10 @@ const ConversionAnalysisPage: React.FC = () => {
                     delta={data.summary.impressions_cvr.delta}
                     isPercentage
                   />
-                  {benchmarkComparison && (
+                  {benchmarkData && (
                     <BenchmarkIndicator
                       clientValue={data.summary.impressions_cvr.value}
-                      benchmark={benchmarkComparison.benchmarks.impressions_to_page_views}
+                      benchmark={benchmarkData.impressions_to_page_views}
                     />
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- connect conversion analysis category dropdown to Supabase benchmarks
- add hook to fetch benchmark data and available categories
- show benchmark indicators for selected category
