### PR TITLE
feat: add benchmark analysis tab

### DIFF
--- a/src/components/BenchmarkAnalysis/BenchmarkAnalysisTab.tsx
+++ b/src/components/BenchmarkAnalysis/BenchmarkAnalysisTab.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo } from 'react';
+import CategorySelector from '@/components/CategorySelector';
+import ComparisonCard from './ComparisonCard';
+import BenchmarkComparisonChart from './BenchmarkComparisonChart';
+import type { AsoData } from '@/hooks/useMockAsoData';
+
+interface BenchmarkAnalysisTabProps {
+  clientData: AsoData;
+  benchmarkData: any;
+  selectedCategory: string;
+  onCategoryChange: (value: string) => void;
+  availableCategories: string[];
+}
+
+const BenchmarkAnalysisTab: React.FC<BenchmarkAnalysisTabProps> = ({
+  clientData,
+  benchmarkData,
+  selectedCategory,
+  onCategoryChange,
+  availableCategories,
+}) => {
+  const clientMetrics = useMemo(() => {
+    if (!clientData?.summary) return null;
+    return {
+      product_page_cvr: clientData.summary.product_page_cvr?.value || 0,
+      impressions_cvr: clientData.summary.impressions_cvr?.value || 0,
+      product_page_cvr_delta: clientData.summary.product_page_cvr?.delta || 0,
+      impressions_cvr_delta: clientData.summary.impressions_cvr?.delta || 0,
+    };
+  }, [clientData]);
+
+  return (
+    <div className="space-y-6">
+      <CategorySelector
+        selectedCategory={selectedCategory}
+        onCategoryChange={onCategoryChange}
+        availableCategories={availableCategories}
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <ComparisonCard
+          title="Product Page CVR"
+          clientValue={clientMetrics?.product_page_cvr ?? 0}
+          benchmarkValue={benchmarkData?.page_views_to_installs ?? 0}
+          clientDelta={clientMetrics?.product_page_cvr_delta ?? 0}
+        />
+
+        <ComparisonCard
+          title="Impressions CVR"
+          clientValue={clientMetrics?.impressions_cvr ?? 0}
+          benchmarkValue={benchmarkData?.impressions_to_page_views ?? 0}
+          clientDelta={clientMetrics?.impressions_cvr_delta ?? 0}
+        />
+      </div>
+
+      <BenchmarkComparisonChart
+        timeseriesData={clientData?.timeseriesData ?? []}
+        benchmarkValue={benchmarkData?.page_views_to_installs ?? 0}
+      />
+    </div>
+  );
+};
+
+export default BenchmarkAnalysisTab;

--- a/src/components/BenchmarkAnalysis/BenchmarkComparisonChart.tsx
+++ b/src/components/BenchmarkAnalysis/BenchmarkComparisonChart.tsx
@@ -1,0 +1,67 @@
+import React, { useMemo } from 'react';
+import { Card } from '@/components/ui/card';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ReferenceLine,
+} from 'recharts';
+import type { TimeSeriesPoint } from '@/hooks/useMockAsoData';
+
+interface BenchmarkComparisonChartProps {
+  timeseriesData: TimeSeriesPoint[];
+  benchmarkValue: number;
+}
+
+const BenchmarkComparisonChart: React.FC<BenchmarkComparisonChartProps> = ({
+  timeseriesData,
+  benchmarkValue,
+}) => {
+  const chartData = useMemo(
+    () =>
+      timeseriesData.map((item) => ({
+        date: item.date,
+        conversion_rate:
+          item.product_page_views > 0
+            ? (item.downloads / item.product_page_views) * 100
+            : 0,
+      })),
+    [timeseriesData]
+  );
+
+  return (
+    <Card className="p-4">
+      <div className="text-sm text-muted-foreground mb-4">
+        Conversion Rate vs Industry Benchmark
+      </div>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" />
+          <YAxis />
+          <Tooltip />
+          <Line
+            type="monotone"
+            dataKey="conversion_rate"
+            stroke="#ef4444"
+            strokeWidth={2}
+            name="Your Performance"
+            dot={false}
+          />
+          <ReferenceLine
+            y={benchmarkValue}
+            stroke="#6b7280"
+            strokeDasharray="5 5"
+            label={`Industry: ${benchmarkValue}%`}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </Card>
+  );
+};
+
+export default BenchmarkComparisonChart;

--- a/src/components/BenchmarkAnalysis/ComparisonCard.tsx
+++ b/src/components/BenchmarkAnalysis/ComparisonCard.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Card } from '@/components/ui/card';
+
+interface ComparisonCardProps {
+  title: string;
+  clientValue: number;
+  benchmarkValue: number;
+  clientDelta: number;
+}
+
+const ComparisonCard: React.FC<ComparisonCardProps> = ({
+  title,
+  clientValue,
+  benchmarkValue,
+  clientDelta,
+}) => {
+  const difference = benchmarkValue
+    ? ((clientValue - benchmarkValue) / benchmarkValue) * 100
+    : 0;
+  const isAbove = clientValue > benchmarkValue;
+  const deltaColor = clientDelta >= 0 ? 'text-green-500' : 'text-red-500';
+  const deltaArrow = clientDelta >= 0 ? '↗' : '↘';
+  const deltaSign = clientDelta >= 0 ? '+' : '';
+
+  return (
+    <Card className="p-4">
+      <div className="text-sm text-muted-foreground mb-2">{title}</div>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-2xl font-bold">{clientValue.toFixed(1)}%</span>
+        <span className={`${deltaColor} text-sm`}>
+          {deltaSign}
+          {clientDelta.toFixed(1)}% {deltaArrow}
+        </span>
+      </div>
+      <div className="border-t pt-3">
+        <div className="text-xs text-muted-foreground mb-1">
+          Industry Average: {benchmarkValue.toFixed(1)}%
+        </div>
+        <div
+          className={`text-xs flex items-center gap-1 ${
+            isAbove ? 'text-green-500' : 'text-red-500'
+          }`}
+        >
+          {isAbove ? '↗' : '↘'} {Math.abs(difference).toFixed(0)}% {
+            isAbove ? 'above' : 'below'
+          } industry
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default ComparisonCard;

--- a/src/pages/conversion-analysis.test.tsx
+++ b/src/pages/conversion-analysis.test.tsx
@@ -71,6 +71,11 @@ jest.mock('../components/BenchmarkIndicator', () => ({
   default: () => <div data-testid="benchmark-indicator">Benchmark Indicator</div>,
 }));
 
+jest.mock('../components/BenchmarkAnalysis/BenchmarkAnalysisTab', () => ({
+  __esModule: true,
+  default: () => <div data-testid="benchmark-analysis-tab">Benchmark Analysis Tab</div>,
+}));
+
 describe('ConversionAnalysisPage', () => {
   const mockData = {
     summary: {

--- a/src/pages/conversion-analysis.tsx
+++ b/src/pages/conversion-analysis.tsx
@@ -17,6 +17,8 @@ import { supabase } from '@/integrations/supabase/client';
 import CategorySelector from '@/components/CategorySelector';
 import BenchmarkIndicator from '@/components/BenchmarkIndicator';
 import { useBenchmarkData } from '../hooks/useBenchmarkData';
+import BenchmarkAnalysisTab from '@/components/BenchmarkAnalysis/BenchmarkAnalysisTab';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 const ConversionAnalysisPage: React.FC = () => {
   const { data, loading } = useAsoData();
@@ -29,6 +31,7 @@ const ConversionAnalysisPage: React.FC = () => {
   const [selectedSources, setSelectedSources] = useState<string[]>([]);
   const [cvrType, setCvrType] = useState<CVRType>('impression');
   const [selectedCategory, setSelectedCategory] = useState<string>('Photo & Video');
+  const [activeTab, setActiveTab] = useState<'performance' | 'benchmark'>('performance');
 
   const trafficSources = data?.trafficSources || [];
   const filteredSources = selectedSources.length > 0
@@ -180,88 +183,110 @@ const ConversionAnalysisPage: React.FC = () => {
                 Insights
               </Button>
             )}
-            <div className="flex items-center gap-4">
-              <h1 className="text-2xl font-bold">Conversion Analysis</h1>
-              <CategorySelector
-                selectedCategory={selectedCategory}
-                onCategoryChange={setSelectedCategory}
-                availableCategories={availableCategories}
-              />
-            </div>
-
-            {/* Cumulative Section */}
-            <section>
-              <h2 className="text-xl font-semibold mb-4">Cumulative</h2>
-              <div className="flex justify-center gap-4">
-                <div className="w-64">
-                  <KpiCard
-                    title="Product Page CVR"
-                    value={data.summary.product_page_cvr.value}
-                    delta={data.summary.product_page_cvr.delta}
-                    isPercentage
+            <Tabs
+              value={activeTab}
+              onValueChange={(value) =>
+                setActiveTab(value as 'performance' | 'benchmark')
+              }
+            >
+              <TabsList className="mb-4">
+                <TabsTrigger value="performance">Performance</TabsTrigger>
+                <TabsTrigger value="benchmark">Benchmark Analysis</TabsTrigger>
+              </TabsList>
+              <TabsContent value="performance" className="space-y-6">
+                <div className="flex items-center gap-4">
+                  <h1 className="text-2xl font-bold">Conversion Analysis</h1>
+                  <CategorySelector
+                    selectedCategory={selectedCategory}
+                    onCategoryChange={setSelectedCategory}
+                    availableCategories={availableCategories}
                   />
-                  {benchmarkData && (
-                    <BenchmarkIndicator
-                      clientValue={data.summary.product_page_cvr.value}
-                      benchmark={benchmarkData.page_views_to_installs}
-                    />
-                  )}
                 </div>
-                <div className="w-64">
-                  <KpiCard
-                    title="Impressions CVR"
-                    value={data.summary.impressions_cvr.value}
-                    delta={data.summary.impressions_cvr.delta}
-                    isPercentage
-                  />
-                  {benchmarkData && (
-                    <BenchmarkIndicator
-                      clientValue={data.summary.impressions_cvr.value}
-                      benchmark={benchmarkData.impressions_to_page_views}
-                    />
-                  )}
-                </div>
-              </div>
-            </section>
 
-            <CVRTypeToggle currentType={cvrType} onTypeChange={setCvrType} />
-
-            <section className="mt-4">
-              <div className="flex flex-col md:flex-row justify-between items-start gap-4 mb-4">
-                <h2 className="text-xl font-semibold">Conversion Rate by Traffic Source</h2>
-                <TrafficSourceSelect
-                  selectedSources={selectedSources}
-                  onSourceChange={setSelectedSources}
-                />
-              </div>
-              <ConversionRateChart data={processedSources} cvrType={cvrType} />
-            </section>
-
-            <section className="mt-8">
-              <h2 className="text-xl font-semibold mb-4">By Traffic Source</h2>
-
-              {processedSources.length === 0 ? (
-                <div className="bg-zinc-800 p-8 rounded-md text-center">
-                  <p className="text-gray-400">No traffic source data available.</p>
-                </div>
-              ) : (
-                <>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-8">
-                    {processedSources.map((source) => (
-                      <TrafficSourceCVRCard key={source.trafficSource} data={source} />
-                    ))}
+                {/* Cumulative Section */}
+                <section>
+                  <h2 className="text-xl font-semibold mb-4">Cumulative</h2>
+                  <div className="flex justify-center gap-4">
+                    <div className="w-64">
+                      <KpiCard
+                        title="Product Page CVR"
+                        value={data.summary.product_page_cvr.value}
+                        delta={data.summary.product_page_cvr.delta}
+                        isPercentage
+                      />
+                      {benchmarkData && (
+                        <BenchmarkIndicator
+                          clientValue={data.summary.product_page_cvr.value}
+                          benchmark={benchmarkData.page_views_to_installs}
+                        />
+                      )}
+                    </div>
+                    <div className="w-64">
+                      <KpiCard
+                        title="Impressions CVR"
+                        value={data.summary.impressions_cvr.value}
+                        delta={data.summary.impressions_cvr.delta}
+                        isPercentage
+                      />
+                      {benchmarkData && (
+                        <BenchmarkIndicator
+                          clientValue={data.summary.impressions_cvr.value}
+                          benchmark={benchmarkData.impressions_to_page_views}
+                        />
+                      )}
+                    </div>
                   </div>
+                </section>
 
-                  <TimeSeriesChart
-                    data={data.timeseriesData}
-                    trafficSourceTimeseriesData={cvrChartData}
-                    mode="breakdown"
-                    showModeToggle={false}
-                    breakdownMetric="cvr"
-                  />
-                </>
-              )}
-            </section>
+                <CVRTypeToggle currentType={cvrType} onTypeChange={setCvrType} />
+
+                <section className="mt-4">
+                  <div className="flex flex-col md:flex-row justify-between items-start gap-4 mb-4">
+                    <h2 className="text-xl font-semibold">Conversion Rate by Traffic Source</h2>
+                    <TrafficSourceSelect
+                      selectedSources={selectedSources}
+                      onSourceChange={setSelectedSources}
+                    />
+                  </div>
+                  <ConversionRateChart data={processedSources} cvrType={cvrType} />
+                </section>
+
+                <section className="mt-8">
+                  <h2 className="text-xl font-semibold mb-4">By Traffic Source</h2>
+
+                  {processedSources.length === 0 ? (
+                    <div className="bg-zinc-800 p-8 rounded-md text-center">
+                      <p className="text-gray-400">No traffic source data available.</p>
+                    </div>
+                  ) : (
+                    <>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-8">
+                        {processedSources.map((source) => (
+                          <TrafficSourceCVRCard key={source.trafficSource} data={source} />
+                        ))}
+                      </div>
+
+                      <TimeSeriesChart
+                        data={data.timeseriesData}
+                        trafficSourceTimeseriesData={cvrChartData}
+                        mode="breakdown"
+                        showModeToggle={false}
+                        breakdownMetric="cvr"
+                      />
+                    </>
+                  )}
+                </section>
+              </TabsContent>
+              <TabsContent value="benchmark">
+                <BenchmarkAnalysisTab
+                  clientData={data}
+                  benchmarkData={benchmarkData}
+                  selectedCategory={selectedCategory}
+                  onCategoryChange={setSelectedCategory}
+                  availableCategories={availableCategories}
+                />
+              </TabsContent>
+            </Tabs>
           </div>
         </div>
         <div


### PR DESCRIPTION
## Summary
- add tab navigation and benchmark analysis tab to conversion analysis page
- compare client conversion rates against industry averages with new comparison cards
- visualize conversion performance versus benchmark using reference line chart
