### PR TITLE
fix: show benchmark data with category selection

### DIFF
--- a/src/components/BenchmarkAnalysis/BenchmarkAnalysisTab.tsx
+++ b/src/components/BenchmarkAnalysis/BenchmarkAnalysisTab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import CategorySelector from '@/components/CategorySelector';
 import ComparisonCard from './ComparisonCard';
 import BenchmarkComparisonChart from './BenchmarkComparisonChart';
@@ -19,6 +19,15 @@ const BenchmarkAnalysisTab: React.FC<BenchmarkAnalysisTabProps> = ({
   onCategoryChange,
   availableCategories,
 }) => {
+  console.log('Benchmark Debug:', {
+    selectedCategory,
+    benchmarkData,
+    availableCategories: availableCategories.length,
+  });
+
+  useEffect(() => {
+    console.log('Benchmark data changed:', benchmarkData);
+  }, [benchmarkData]);
   const clientMetrics = useMemo(() => {
     if (!clientData?.summary) return null;
     return {

--- a/src/components/BenchmarkAnalysis/BenchmarkComparisonChart.tsx
+++ b/src/components/BenchmarkAnalysis/BenchmarkComparisonChart.tsx
@@ -52,12 +52,14 @@ const BenchmarkComparisonChart: React.FC<BenchmarkComparisonChartProps> = ({
             name="Your Performance"
             dot={false}
           />
-          <ReferenceLine
-            y={benchmarkValue}
-            stroke="#6b7280"
-            strokeDasharray="5 5"
-            label={`Industry: ${benchmarkValue}%`}
-          />
+          {benchmarkValue > 0 && (
+            <ReferenceLine
+              y={benchmarkValue}
+              stroke="#6b7280"
+              strokeDasharray="5 5"
+              label={`Industry: ${benchmarkValue.toFixed(1)}%`}
+            />
+          )}
         </LineChart>
       </ResponsiveContainer>
     </Card>

--- a/src/components/BenchmarkAnalysis/ComparisonCard.tsx
+++ b/src/components/BenchmarkAnalysis/ComparisonCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Card } from '@/components/ui/card';
+import BenchmarkIndicator from '@/components/BenchmarkIndicator';
 
 interface ComparisonCardProps {
   title: string;
@@ -14,13 +15,11 @@ const ComparisonCard: React.FC<ComparisonCardProps> = ({
   benchmarkValue,
   clientDelta,
 }) => {
-  const difference = benchmarkValue
-    ? ((clientValue - benchmarkValue) / benchmarkValue) * 100
-    : 0;
-  const isAbove = clientValue > benchmarkValue;
+  console.log(`${title} - Client: ${clientValue}, Benchmark: ${benchmarkValue}`);
   const deltaColor = clientDelta >= 0 ? 'text-green-500' : 'text-red-500';
   const deltaArrow = clientDelta >= 0 ? '↗' : '↘';
   const deltaSign = clientDelta >= 0 ? '+' : '';
+  const hasBenchmark = benchmarkValue && benchmarkValue > 0;
 
   return (
     <Card className="p-4">
@@ -34,17 +33,16 @@ const ComparisonCard: React.FC<ComparisonCardProps> = ({
       </div>
       <div className="border-t pt-3">
         <div className="text-xs text-muted-foreground mb-1">
-          Industry Average: {benchmarkValue.toFixed(1)}%
+          Industry Average: {hasBenchmark ? benchmarkValue.toFixed(1) : 'Loading...'}%
         </div>
-        <div
-          className={`text-xs flex items-center gap-1 ${
-            isAbove ? 'text-green-500' : 'text-red-500'
-          }`}
-        >
-          {isAbove ? '↗' : '↘'} {Math.abs(difference).toFixed(0)}% {
-            isAbove ? 'above' : 'below'
-          } industry
-        </div>
+        {hasBenchmark ? (
+          <BenchmarkIndicator
+            clientValue={clientValue}
+            benchmarkValue={benchmarkValue}
+          />
+        ) : (
+          <div className="text-xs text-muted-foreground">No benchmark data</div>
+        )}
       </div>
     </Card>
   );

--- a/src/components/BenchmarkIndicator.tsx
+++ b/src/components/BenchmarkIndicator.tsx
@@ -2,26 +2,26 @@ import React from 'react';
 
 interface BenchmarkIndicatorProps {
   clientValue: number;
-  benchmark: number;
+  benchmarkValue: number;
 }
 
-const BenchmarkIndicator: React.FC<BenchmarkIndicatorProps> = ({ clientValue, benchmark }) => {
-  const performance = clientValue > benchmark ? 'above' : clientValue < benchmark ? 'below' : 'at';
-  const color =
-    performance === 'above'
-      ? 'text-green-600'
-      : performance === 'below'
-      ? 'text-red-600'
-      : 'text-yellow-600';
-  const symbol = performance === 'above' ? '↗' : performance === 'below' ? '↘' : '→';
-  const text = performance === 'above' ? 'Above' : performance === 'below' ? 'Below' : 'At';
+const BenchmarkIndicator: React.FC<BenchmarkIndicatorProps> = ({
+  clientValue,
+  benchmarkValue,
+}) => {
+  if (!benchmarkValue) {
+    return <div className="text-xs text-muted-foreground">No benchmark data</div>;
+  }
+
+  const difference = ((clientValue - benchmarkValue) / benchmarkValue) * 100;
+  const isAbove = clientValue > benchmarkValue;
+  const color = isAbove ? 'text-green-500' : 'text-red-500';
+  const arrow = isAbove ? '↗' : '↘';
+  const comparison = isAbove ? 'above' : 'below';
 
   return (
-    <div className="text-xs mt-1">
-      <span className="text-muted-foreground">Industry: {benchmark}%</span>
-      <span className={`ml-2 ${color}`}>
-        {symbol} {text} benchmark
-      </span>
+    <div className={`text-xs flex items-center gap-1 ${color}`}>
+      {arrow} {Math.abs(difference).toFixed(0)}% {comparison} industry
     </div>
   );
 };

--- a/src/pages/conversion-analysis.tsx
+++ b/src/pages/conversion-analysis.tsx
@@ -217,7 +217,7 @@ const ConversionAnalysisPage: React.FC = () => {
                       {benchmarkData && (
                         <BenchmarkIndicator
                           clientValue={data.summary.product_page_cvr.value}
-                          benchmark={benchmarkData.page_views_to_installs}
+                          benchmarkValue={benchmarkData.page_views_to_installs}
                         />
                       )}
                     </div>
@@ -231,7 +231,7 @@ const ConversionAnalysisPage: React.FC = () => {
                       {benchmarkData && (
                         <BenchmarkIndicator
                           clientValue={data.summary.impressions_cvr.value}
-                          benchmark={benchmarkData.impressions_to_page_views}
+                          benchmarkValue={benchmarkData.impressions_to_page_views}
                         />
                       )}
                     </div>


### PR DESCRIPTION
## Summary
- log benchmark data flow in BenchmarkAnalysisTab for easier debugging
- improve benchmark indicator and comparison cards to reflect industry averages
- hide chart reference line until benchmark data is available
