### PR TITLE
feat: add router-level auth guards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { AsoAiHubProvider } from "./context/AsoAiHubContext";
 import { WorkflowProvider } from "./context/WorkflowContext";
 import { BigQueryAppProvider } from "./context/BigQueryAppContext";
 import { BrandedLoadingSpinner } from "@/components/ui/LoadingSkeleton";
+import ProtectedRoute from "@/components/Auth/ProtectedRoute";
 
 // Lazy load components
 const Index = lazy(() => import("./pages/Index"));
@@ -61,28 +62,88 @@ function App() {
                           <Route path="/auth/sign-in" element={<SignIn />} />
                           <Route path="/auth/sign-up" element={<SignUp />} />
                           <Route path="/" element={<Index />} />
-                          <Route path="/dashboard" element={<Dashboard />} />
-                          <Route path="/traffic-sources" element={<TrafficSources />} />
-                          <Route path="/insights" element={<InsightsPage />} />
-                          <Route path="/insights/traffic-performance" element={<TrafficPerformanceMatrix />} />
-                          <Route path="/conversion-analysis" element={<ConversionAnalysis />} />
-                          <Route path="/overview" element={<Overview />} />
-                          
-                          <Route path="/aso-ai-hub" element={<AsoAiHub />} />
-                          <Route path="/chatgpt-visibility-audit" element={<ChatGPTVisibilityAudit />} />
-                          
-                          <Route path="/featuring-toolkit" element={<FeaturingToolkit />} />
-                          <Route path="/metadata-copilot" element={<MetadataCopilot />} />
-                          <Route path="/growth-gap-copilot" element={<GrowthGapCopilot />} />
-                          <Route path="/creative-analysis" element={<CreativeAnalysis />} />
-                          <Route path="/aso-knowledge-engine" element={<AsoKnowledgeEngine />} />
-                          <Route path="/aso-unified" element={<ASOUnified />} />
-                          <Route path="/apps" element={<Apps />} />
-                          <Route path="/app-discovery" element={<AppDiscovery />} />
-                          <Route path="/profile" element={<Profile />} />
-                          <Route path="/settings" element={<Settings />} />
-                          <Route path="/admin" element={<Admin />} />
-                          <Route path="/smoke-test" element={<SmokeTest />} />
+                          <Route
+                            path="/dashboard"
+                            element={<ProtectedRoute><Dashboard /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/traffic-sources"
+                            element={<ProtectedRoute><TrafficSources /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/insights"
+                            element={<ProtectedRoute><InsightsPage /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/insights/traffic-performance"
+                            element={<ProtectedRoute><TrafficPerformanceMatrix /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/conversion-analysis"
+                            element={<ProtectedRoute><ConversionAnalysis /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/overview"
+                            element={<ProtectedRoute><Overview /></ProtectedRoute>}
+                          />
+
+                          <Route
+                            path="/aso-ai-hub"
+                            element={<ProtectedRoute><AsoAiHub /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/chatgpt-visibility-audit"
+                            element={<ProtectedRoute><ChatGPTVisibilityAudit /></ProtectedRoute>}
+                          />
+
+                          <Route
+                            path="/featuring-toolkit"
+                            element={<ProtectedRoute><FeaturingToolkit /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/metadata-copilot"
+                            element={<ProtectedRoute><MetadataCopilot /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/growth-gap-copilot"
+                            element={<ProtectedRoute><GrowthGapCopilot /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/creative-analysis"
+                            element={<ProtectedRoute><CreativeAnalysis /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/aso-knowledge-engine"
+                            element={<ProtectedRoute><AsoKnowledgeEngine /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/aso-unified"
+                            element={<ProtectedRoute><ASOUnified /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/apps"
+                            element={<ProtectedRoute><Apps /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/app-discovery"
+                            element={<ProtectedRoute><AppDiscovery /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/profile"
+                            element={<ProtectedRoute><Profile /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/settings"
+                            element={<ProtectedRoute><Settings /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/admin"
+                            element={<ProtectedRoute><Admin /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/smoke-test"
+                            element={<ProtectedRoute><SmokeTest /></ProtectedRoute>}
+                          />
                           <Route path="/404" element={<NotFound />} />
                           <Route path="*" element={<Navigate to="/404" replace />} />
                         </Routes>

--- a/src/components/Auth/AuthLoadingSpinner.tsx
+++ b/src/components/Auth/AuthLoadingSpinner.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { BrandedLoadingSpinner } from '@/components/ui/LoadingSkeleton';
+
+/** Minimal spinner shown while verifying authentication */
+export const AuthLoadingSpinner: React.FC = () => {
+  return <BrandedLoadingSpinner message="Checking authentication" />;
+};
+
+export default AuthLoadingSpinner;

--- a/src/components/Auth/ProtectedRoute.tsx
+++ b/src/components/Auth/ProtectedRoute.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
+import { AuthLoadingSpinner } from '@/components/Auth/AuthLoadingSpinner';
+import { useUserProfile } from '@/hooks/useUserProfile';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const { user, loading } = useAuth();
+  const { profile, isLoading: profileLoading } = useUserProfile();
+  const location = useLocation();
+
+  // Show spinner while auth or profile are loading
+  if (loading || (user && profileLoading)) {
+    return <AuthLoadingSpinner />;
+  }
+
+  // If no authenticated user, store intended path and redirect to sign in
+  if (!user) {
+    const intended = location.pathname + location.search;
+    sessionStorage.setItem('postLoginRedirect', intended);
+    return <Navigate to="/auth/sign-in" replace />;
+  }
+
+  // If user lacks organization, redirect to app selection/assignment
+  if (profile && !profile.organization_id) {
+    return <Navigate to="/apps" replace />;
+  }
+
+  // Clear any stored intent once authenticated and organization validated
+  sessionStorage.removeItem('postLoginRedirect');
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -114,12 +114,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         email,
         password,
       });
-      
+
       if (error) {
         throw error;
       }
-      
-      navigate('/dashboard');
+      // Restore navigation intent if present
+      const redirectPath = sessionStorage.getItem('postLoginRedirect') || '/dashboard';
+      navigate(redirectPath);
+      sessionStorage.removeItem('postLoginRedirect');
       return data;
     } catch (error: any) {
       toast({
@@ -150,17 +152,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signInWithOAuth = async ({ provider }: { provider: 'google' | 'github' | 'twitter' }) => {
     try {
+      const redirectPath = sessionStorage.getItem('postLoginRedirect') || '/dashboard';
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider,
         options: {
-          redirectTo: `${window.location.origin}/dashboard`
+          redirectTo: `${window.location.origin}${redirectPath}`
         }
       });
-      
+
       if (error) {
         throw error;
       }
-      
+
       return data;
     } catch (error: any) {
       toast({


### PR DESCRIPTION
## Summary
- add `ProtectedRoute` with auth and organization checks
- preserve navigation intent and handle redirects in AuthContext
- wrap protected paths with `ProtectedRoute`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build` *(fails: CSS @import ordering issue)*

------
https://chatgpt.com/codex/tasks/task_e_689cf72a47b083269442dd672724cf88