### PR TITLE
feat: add interactive benchmark cards and graph

### DIFF
--- a/src/components/ConversionIntelligence/BenchmarkCards.tsx
+++ b/src/components/ConversionIntelligence/BenchmarkCards.tsx
@@ -1,0 +1,125 @@
+import React, { useCallback } from 'react';
+import { CheckCircle } from 'lucide-react';
+import { BenchmarkMetric } from '@/hooks/useBigQueryData';
+
+interface BenchmarkCardProps {
+  metric: BenchmarkMetric;
+  isSelected: boolean;
+  onClick: (metricId: BenchmarkMetric['id']) => void;
+  loading?: boolean;
+  disabled?: boolean;
+}
+
+const BenchmarkCard: React.FC<BenchmarkCardProps> = ({
+  metric,
+  isSelected,
+  onClick,
+  loading = false,
+  disabled = false
+}) => {
+  const handleCardClick = useCallback(() => {
+    if (!loading && !disabled) {
+      onClick(metric.id);
+    }
+  }, [metric.id, onClick, loading, disabled]);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleCardClick();
+    }
+  }, [handleCardClick]);
+
+  return (
+    <div
+      className={`
+        benchmark-card relative cursor-pointer transition-all duration-200 ease-in-out
+        ${isSelected ? 'ring-2 ring-blue-500 bg-blue-50 border-blue-200' : 'border-gray-200 hover:border-blue-300 hover:bg-gray-50'}
+        ${loading ? 'pointer-events-none opacity-60' : ''}
+        ${disabled ? 'pointer-events-none opacity-40' : ''}
+        border rounded-lg p-4 min-h-[140px] focus:outline-none focus:ring-2 focus:ring-blue-500
+      `}
+      onClick={handleCardClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-pressed={isSelected}
+      aria-label={`Select ${metric.name} for benchmark analysis`}
+      aria-describedby={`${metric.id}-description`}
+    >
+      {isSelected && (
+        <div className="absolute top-2 right-2">
+          <CheckCircle className="w-5 h-5 text-blue-600" />
+        </div>
+      )}
+
+      <div className="flex justify-between items-start mb-3">
+        <h3 className="font-semibold text-gray-900 text-sm">
+          {metric.name}
+        </h3>
+        <div className={`text-xs px-2 py-1 rounded ${
+          metric.currentValue > metric.benchmarkValue ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+        }`}>
+          {metric.currentValue > metric.benchmarkValue ? 'Above' : 'Below'} Benchmark
+        </div>
+      </div>
+
+      <div className="mb-2">
+        <div className="text-2xl font-bold text-gray-900">
+          {metric.currentValue.toFixed(1)}{metric.unit}
+        </div>
+        <div className="text-xs text-gray-500">Current Performance</div>
+      </div>
+
+      <div className="space-y-1">
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-600">Industry Avg:</span>
+          <span className="font-medium">
+            {metric.benchmarkValue.toFixed(1)}{metric.unit}
+          </span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-600">Trend:</span>
+          <span className={`font-medium flex items-center ${
+            metric.trend >= 0 ? 'text-green-600' : 'text-red-600'
+          }`}>
+            {metric.trend >= 0 ? '↗' : '↘'} {Math.abs(metric.trend).toFixed(1)}%
+          </span>
+        </div>
+      </div>
+
+      {loading && (
+        <div className="absolute inset-0 bg-white bg-opacity-75 flex items-center justify-center rounded-lg">
+          <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+        </div>
+      )}
+
+      <div id={`${metric.id}-description`} className="sr-only">
+        {metric.description}
+      </div>
+    </div>
+  );
+};
+
+const BenchmarkCards: React.FC<{
+  metrics: BenchmarkMetric[];
+  selectedMetric: BenchmarkMetric['id'];
+  onMetricSelect: (metricId: BenchmarkMetric['id']) => void;
+  loading?: boolean;
+}> = ({ metrics, selectedMetric, onMetricSelect, loading = false }) => {
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+      {metrics.map((metric) => (
+        <BenchmarkCard
+          key={metric.id}
+          metric={metric}
+          isSelected={selectedMetric === metric.id}
+          onClick={onMetricSelect}
+          loading={loading}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default BenchmarkCards;

--- a/src/components/ConversionIntelligence/BenchmarkGraph.tsx
+++ b/src/components/ConversionIntelligence/BenchmarkGraph.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from 'react';
+import { ResponsiveContainer, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts';
+import { BarChart3 as ChartBarIcon } from 'lucide-react';
+import { BenchmarkMetric, GraphDataPoint } from '@/hooks/useBigQueryData';
+
+interface BenchmarkGraphProps {
+  data: GraphDataPoint[];
+  selectedMetric: BenchmarkMetric;
+  loading: boolean;
+  dateRange: { startDate: string; endDate: string };
+  height?: number;
+}
+
+const BenchmarkGraph: React.FC<BenchmarkGraphProps> = ({
+  data,
+  selectedMetric,
+  loading,
+  dateRange,
+  height = 400
+}) => {
+  const chartConfig = useMemo(() => ({
+    data: data,
+    margin: { top: 20, right: 30, left: 40, bottom: 60 },
+    height: height,
+    colors: {
+      current: '#3B82F6',
+      benchmark: '#9CA3AF',
+      industryAverage: '#10B981'
+    }
+  }), [data, height]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center" style={{ height }}>
+        <div className="text-center">
+          <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-2"></div>
+          <div className="text-sm text-gray-500">Loading {selectedMetric.name} data...</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex items-center justify-center" style={{ height }}>
+        <div className="text-center text-gray-500">
+          <ChartBarIcon className="w-12 h-12 mx-auto mb-2 text-gray-300" />
+          <div>No data available for selected period</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg border p-6">
+      <div className="flex justify-between items-center mb-4">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">
+            {selectedMetric.name} Trends
+          </h3>
+          <div className="text-sm text-gray-500">
+            {dateRange.startDate} to {dateRange.endDate}
+          </div>
+        </div>
+
+        <div className="flex items-center space-x-4 text-sm">
+          <div className="flex items-center">
+            <div className="w-3 h-3 bg-blue-500 rounded mr-2"></div>
+            Your Performance
+          </div>
+          <div className="flex items-center">
+            <div className="w-3 h-3 bg-gray-400 rounded mr-2"></div>
+            Industry Benchmark
+          </div>
+          <div className="flex items-center">
+            <div className="w-3 h-3 bg-green-500 rounded mr-2"></div>
+            Industry Average
+          </div>
+        </div>
+      </div>
+
+      <ResponsiveContainer width="100%" height={height}>
+        <LineChart data={chartConfig.data} margin={chartConfig.margin}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" />
+          <XAxis
+            dataKey="date"
+            stroke="#6B7280"
+            fontSize={12}
+            tickFormatter={(date) => new Date(date).toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric'
+            })}
+          />
+          <YAxis
+            stroke="#6B7280"
+            fontSize={12}
+            tickFormatter={(value) => `${value.toFixed(1)}${selectedMetric.unit}`}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#FFFFFF',
+              border: '1px solid #E5E7EB',
+              borderRadius: '6px',
+              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
+            }}
+            formatter={(value: number, name: string) => [
+              `${value.toFixed(1)}${selectedMetric.unit}`,
+              name === 'current' ? 'Your Performance' :
+              name === 'benchmark' ? 'Industry Benchmark' : 'Industry Average'
+            ]}
+            labelFormatter={(date) => new Date(date).toLocaleDateString('en-US', {
+              weekday: 'short',
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric'
+            })}
+          />
+          <Line
+            type="monotone"
+            dataKey="current"
+            stroke={chartConfig.colors.current}
+            strokeWidth={2}
+            dot={{ fill: chartConfig.colors.current, r: 4 }}
+            activeDot={{ r: 6, stroke: chartConfig.colors.current, strokeWidth: 2 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="benchmark"
+            stroke={chartConfig.colors.benchmark}
+            strokeWidth={2}
+            strokeDasharray="5 5"
+            dot={{ fill: chartConfig.colors.benchmark, r: 3 }}
+          />
+          {data.some(d => d.industryAverage) && (
+            <Line
+              type="monotone"
+              dataKey="industryAverage"
+              stroke={chartConfig.colors.industryAverage}
+              strokeWidth={1}
+              strokeDasharray="2 2"
+              dot={false}
+            />
+          )}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default BenchmarkGraph;

--- a/src/components/ConversionIntelligence/BenchmarkTab.tsx
+++ b/src/components/ConversionIntelligence/BenchmarkTab.tsx
@@ -1,0 +1,96 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import BenchmarkCards from './BenchmarkCards';
+import BenchmarkGraph from './BenchmarkGraph';
+import { useBenchmarkData, BenchmarkMetric, GraphDataPoint } from '@/hooks/useBigQueryData';
+
+const ALLOWED_METRICS = ['product_page_cvr', 'impressions_cvr', 'search_cvr', 'browse_cvr'] as const;
+const METRIC_WHITELIST = new Set(ALLOWED_METRICS);
+
+const validateMetricSelection = (metric: string): metric is BenchmarkMetric['id'] => {
+  return METRIC_WHITELIST.has(metric as BenchmarkMetric['id']);
+};
+
+const sanitizeMetricName = (name: string): string => {
+  return name.replace(/[<>"'&]/g, (match) => {
+    const escapeMap: Record<string, string> = {
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#x27;',
+      '&': '&amp;'
+    };
+    return escapeMap[match];
+  });
+};
+
+interface BenchmarkTabProps {
+  organizationId: string;
+  dateRange: { startDate: string; endDate: string };
+  trafficSources?: string[];
+}
+
+const BenchmarkTab: React.FC<BenchmarkTabProps> = ({
+  organizationId,
+  dateRange,
+  trafficSources = []
+}) => {
+  const [selectedMetric, setSelectedMetric] = useState<BenchmarkMetric['id']>('product_page_cvr');
+  const [metricsData, setMetricsData] = useState<BenchmarkMetric[]>([]);
+  const [graphData, setGraphData] = useState<GraphDataPoint[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const { data, metrics, loading: hookLoading, refetch } = useBenchmarkData({
+    organizationId,
+    selectedMetric,
+    dateRange,
+    trafficSources
+  });
+
+  useEffect(() => {
+    setMetricsData(metrics.map(m => ({ ...m, name: sanitizeMetricName(m.name) })));
+  }, [metrics]);
+
+  useEffect(() => {
+    setGraphData(data);
+  }, [data]);
+
+  useEffect(() => {
+    setLoading(hookLoading);
+  }, [hookLoading]);
+
+  const fetchBenchmarkGraphData = useCallback((metricId: BenchmarkMetric['id']) => {
+    refetch(metricId);
+  }, [refetch]);
+
+  const handleMetricSelection = useCallback((metricId: BenchmarkMetric['id']) => {
+    if (validateMetricSelection(metricId)) {
+      setSelectedMetric(metricId);
+      fetchBenchmarkGraphData(metricId);
+    } else {
+      console.warn('Invalid metric selection attempted:', metricId);
+    }
+  }, [fetchBenchmarkGraphData]);
+
+  const currentMetric = metricsData.find(m => m.id === selectedMetric);
+
+  return (
+    <div>
+      <BenchmarkCards
+        metrics={metricsData}
+        selectedMetric={selectedMetric}
+        onMetricSelect={handleMetricSelection}
+        loading={loading}
+      />
+      {currentMetric && (
+        <BenchmarkGraph
+          data={graphData}
+          selectedMetric={currentMetric}
+          loading={loading}
+          dateRange={dateRange}
+        />
+      )}
+    </div>
+  );
+};
+
+export default BenchmarkTab;


### PR DESCRIPTION
## Summary
- add benchmark metric selection and sanitization with dynamic graph updates
- introduce interactive benchmark cards with loading and accessibility states
- implement secure benchmark data hook for fetching graph and metric info

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any types in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_689daae02a0483268fe28d57430c3f75