### PR TITLE
Guard ASO insight hooks and async cleanup

### DIFF
--- a/src/hooks/useConversationalChat.ts
+++ b/src/hooks/useConversationalChat.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import type { MetricsData, FilterContext } from '@/types/aso';
 
@@ -16,6 +16,13 @@ export const useConversationalChat = ({
   // Ensure stable initialization with proper guards
   const [isGenerating, setIsGenerating] = useState(() => false);
   const [error, setError] = useState<string | null>(() => null);
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   const generateChatResponse = async (userQuestion: string): Promise<string> => {
     if (!metricsData) {
@@ -46,10 +53,14 @@ export const useConversationalChat = ({
       return data.response;
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to generate response';
-      setError(errorMessage);
+      if (isMounted.current) {
+        setError(errorMessage);
+      }
       throw new Error(errorMessage);
     } finally {
-      setIsGenerating(false);
+      if (isMounted.current) {
+        setIsGenerating(false);
+      }
     }
   };
 

--- a/src/hooks/useEnhancedAsoInsights.ts
+++ b/src/hooks/useEnhancedAsoInsights.ts
@@ -69,30 +69,9 @@ export const useEnhancedAsoInsights = (
     retry: 2,
     retryDelay: attemptIndex => Math.min(1000 * 2 ** attemptIndex, 30000)
   });
-
-  // Super admin without organization - return empty state after hooks
-  if (isSuperAdmin && !hasValidOrganization) {
-    return {
-      insights: [],
-      highPriorityInsights: [],
-      userRequestedInsights: [],
-      isLoading: false,
-      isGenerating: false,
-      error: null,
-      generateConversionAnalysis: async () => [],
-      generateImpressionTrends: async () => [],
-      generateTrafficSourceAnalysis: async () => [],
-      generateKeywordOptimization: async () => [],
-      generateSeasonalAnalysis: async () => [],
-      generateComprehensiveInsights: async () => [],
-      refetchInsights: async () => {},
-      hasInsightType: () => false
-    };
-  }
-
   // Generate AI insights for specific analysis type
   const generateInsight = useCallback(async (
-    insightType: string, 
+    insightType: string,
     userRequested: boolean = true
   ): Promise<EnhancedAsoInsight[]> => {
     // Super admin without organization - return empty
@@ -188,6 +167,26 @@ export const useEnhancedAsoInsights = (
   const userRequestedInsights = existingInsights.filter(
     insight => insight.is_user_requested
   );
+
+  // Super admin without organization - return empty state after hooks
+  if (isSuperAdmin && !hasValidOrganization) {
+    return {
+      insights: [],
+      highPriorityInsights: [],
+      userRequestedInsights: [],
+      isLoading: false,
+      isGenerating: false,
+      error: null,
+      generateConversionAnalysis: async () => [],
+      generateImpressionTrends: async () => [],
+      generateTrafficSourceAnalysis: async () => [],
+      generateKeywordOptimization: async () => [],
+      generateSeasonalAnalysis: async () => [],
+      generateComprehensiveInsights: async () => [],
+      refetchInsights: async () => {},
+      hasInsightType: () => false
+    };
+  }
 
   return {
     // Data

--- a/src/pages/conversion-analysis.tsx
+++ b/src/pages/conversion-analysis.tsx
@@ -24,7 +24,7 @@ import { usePermissions } from '@/hooks/usePermissions';
 const ConversionAnalysisPage: React.FC = () => {
   const { data, loading } = useAsoData();
   const { user } = useAuth();
-  const { isSuperAdmin } = usePermissions();
+  const { isSuperAdmin, isLoading: permissionsLoading } = usePermissions();
   const [organizationId, setOrganizationId] = useState('');
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
@@ -151,13 +151,15 @@ const ConversionAnalysisPage: React.FC = () => {
                 : 'fixed right-0 top-0 h-full z-10'
             }
           >
-            <ContextualInsightsSidebar
-              metricsData={data}
-              organizationId={organizationId}
-              state={sidebarState}
-              onStateChange={handleSidebarStateChange}
-              isSuperAdmin={isSuperAdmin}
-            />
+            {!permissionsLoading && (
+              <ContextualInsightsSidebar
+                metricsData={data}
+                organizationId={organizationId}
+                state={sidebarState}
+                onStateChange={handleSidebarStateChange}
+                isSuperAdmin={isSuperAdmin}
+              />
+            )}
           </div>
           {isMobile && isMobileSidebarOpen && (
             <div
@@ -301,13 +303,15 @@ const ConversionAnalysisPage: React.FC = () => {
               : 'fixed right-0 top-0 h-full z-10'
           }
         >
-          <ContextualInsightsSidebar
-            metricsData={data}
-            organizationId={organizationId}
-            state={sidebarState}
-            onStateChange={handleSidebarStateChange}
-            isSuperAdmin={isSuperAdmin}
-          />
+          {!permissionsLoading && (
+            <ContextualInsightsSidebar
+              metricsData={data}
+              organizationId={organizationId}
+              state={sidebarState}
+              onStateChange={handleSidebarStateChange}
+              isSuperAdmin={isSuperAdmin}
+            />
+          )}
         </div>
         {isMobile && isMobileSidebarOpen && (
           <div

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -38,7 +38,7 @@ const Dashboard: React.FC = () => {
     meta
   } = useAsoData();
   const { user } = useAuth();
-  const { isSuperAdmin } = usePermissions();
+  const { isSuperAdmin, isLoading: permissionsLoading } = usePermissions();
   const { selectedOrganizationId, setSelectedOrganizationId, isPlatformWideMode } = useSuperAdmin();
   const [organizationId, setOrganizationId] = useState('');
   const [sidebarState, setSidebarState] = useState<SidebarState>('normal');
@@ -361,21 +361,23 @@ const Dashboard: React.FC = () => {
 
         {/* Sidebar - Pass collapse state */}
         <div className="fixed right-0 top-0 h-full z-10">
-          {isDashboardDataReady ? (
-            <ContextualInsightsSidebar
-              metricsData={data}
-              organizationId={organizationId}
-              state={sidebarState}
-              onStateChange={handleSidebarStateChange}
-              isSuperAdmin={isSuperAdmin}
-            />
-          ) : (
-            <div className="w-80 h-screen bg-background/50 border-l border-border flex items-center justify-center">
-              <div className="text-center">
-                <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-2" />
-                <p className="text-sm text-muted-foreground">Loading dashboard data...</p>
+          {!permissionsLoading && (
+            isDashboardDataReady ? (
+              <ContextualInsightsSidebar
+                metricsData={data}
+                organizationId={organizationId}
+                state={sidebarState}
+                onStateChange={handleSidebarStateChange}
+                isSuperAdmin={isSuperAdmin}
+              />
+            ) : (
+              <div className="w-80 h-screen bg-background/50 border-l border-border flex items-center justify-center">
+                <div className="text-center">
+                  <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-2" />
+                  <p className="text-sm text-muted-foreground">Loading dashboard data...</p>
+                </div>
               </div>
-            </div>
+            )
           )}
         </div>
     </MainLayout>

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -38,7 +38,7 @@ import { usePermissions } from '@/hooks/usePermissions';
 const OverviewPage: React.FC = () => {
   const { data, loading } = useAsoData();
   const { user } = useAuth();
-  const { isSuperAdmin } = usePermissions();
+  const { isSuperAdmin, isLoading: permissionsLoading } = usePermissions();
   const [organizationId, setOrganizationId] = useState('');
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
@@ -177,13 +177,15 @@ const OverviewPage: React.FC = () => {
                 : 'fixed right-0 top-0 h-full z-10'
             }
           >
-            <ContextualInsightsSidebar
-              metricsData={data}
-              organizationId={organizationId}
-              state={sidebarState}
-              onStateChange={handleSidebarStateChange}
-              isSuperAdmin={isSuperAdmin}
-            />
+            {!permissionsLoading && (
+              <ContextualInsightsSidebar
+                metricsData={data}
+                organizationId={organizationId}
+                state={sidebarState}
+                onStateChange={handleSidebarStateChange}
+                isSuperAdmin={isSuperAdmin}
+              />
+            )}
           </div>
           {isMobile && isMobileSidebarOpen && (
             <div
@@ -433,13 +435,15 @@ const OverviewPage: React.FC = () => {
               : 'fixed right-0 top-0 h-full z-10'
           }
         >
-          <ContextualInsightsSidebar
-            metricsData={data}
-            organizationId={organizationId}
-            state={sidebarState}
-            onStateChange={handleSidebarStateChange}
-            isSuperAdmin={isSuperAdmin}
-          />
+          {!permissionsLoading && (
+            <ContextualInsightsSidebar
+              metricsData={data}
+              organizationId={organizationId}
+              state={sidebarState}
+              onStateChange={handleSidebarStateChange}
+              isSuperAdmin={isSuperAdmin}
+            />
+          )}
         </div>
         {isMobile && isMobileSidebarOpen && (
           <div


### PR DESCRIPTION
## Summary
- ensure `useEnhancedAsoInsights` always calls the same hooks and safely returns no-ops for super admins without an org
- prevent `useConversationalChat` from updating state after unmount
- delay `ContextualInsightsSidebar` rendering until permissions load on overview, conversion analysis, and dashboard pages
- confirm single React instance in dependency tree

## Testing
- `npm ls react react-dom`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f25eca5d08326a57460c750e2575e