### PR TITLE
feat: add admin user and organization management

### DIFF
--- a/src/components/admin/organizations/CreateOrganizationModal.tsx
+++ b/src/components/admin/organizations/CreateOrganizationModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 interface CreateOrganizationModalProps {
   onClose: () => void;
@@ -6,22 +6,86 @@ interface CreateOrganizationModalProps {
 }
 
 export const CreateOrganizationModal: React.FC<CreateOrganizationModalProps> = ({ onClose, onSuccess }) => {
+  const [formData, setFormData] = useState({
+    name: '',
+    slug: '',
+    domain: '',
+    subscription_tier: 'professional'
+  });
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const response = await fetch('/api/admin/organizations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      });
+      if (!response.ok) throw new Error('Failed to create organization');
+      await response.json();
+      onSuccess();
+    } catch (error) {
+      console.error('Failed to create organization:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
       <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow w-full max-w-md">
-        <h2 className="text-lg font-semibold mb-4">Create Organization</h2>
-        <p className="text-sm mb-4">This is a placeholder modal.</p>
-        <div className="flex justify-end space-x-2">
-          <button className="px-3 py-1 text-sm" onClick={onClose}>
-            Cancel
-          </button>
-          <button
-            className="px-3 py-1 text-sm bg-orange-600 text-white rounded"
-            onClick={onSuccess}
-          >
-            Save
-          </button>
-        </div>
+        <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-white">Create Organization</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Name</label>
+            <input
+              type="text"
+              required
+              value={formData.name}
+              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              className="w-full px-3 py-2 border rounded-md bg-gray-50 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Slug</label>
+            <input
+              type="text"
+              required
+              value={formData.slug}
+              onChange={(e) => setFormData({ ...formData, slug: e.target.value })}
+              className="w-full px-3 py-2 border rounded-md bg-gray-50 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Domain</label>
+            <input
+              type="text"
+              value={formData.domain}
+              onChange={(e) => setFormData({ ...formData, domain: e.target.value })}
+              className="w-full px-3 py-2 border rounded-md bg-gray-50 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Subscription Tier</label>
+            <select
+              value={formData.subscription_tier}
+              onChange={(e) => setFormData({ ...formData, subscription_tier: e.target.value })}
+              className="w-full px-3 py-2 border rounded-md bg-gray-50 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="starter">Starter</option>
+              <option value="professional">Professional</option>
+              <option value="enterprise">Enterprise</option>
+            </select>
+          </div>
+          <div className="flex justify-end space-x-2 pt-2">
+            <button type="button" onClick={onClose} className="px-3 py-1 text-sm border rounded-md">Cancel</button>
+            <button type="submit" disabled={loading} className="px-3 py-1 text-sm bg-orange-600 text-white rounded-md disabled:opacity-50">
+              {loading ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   );

--- a/src/components/admin/users/UserEditModal.tsx
+++ b/src/components/admin/users/UserEditModal.tsx
@@ -1,0 +1,149 @@
+import React, { useState, useEffect } from 'react';
+import { X, Edit3 } from 'lucide-react';
+
+interface UserEditModalProps {
+  user: {
+    id: string;
+    first_name?: string;
+    last_name?: string;
+    role: string;
+    organization_id: string;
+  };
+  onClose: () => void;
+  onSave: (updates: {
+    first_name?: string;
+    last_name?: string;
+    role?: string;
+    organization_id?: string;
+  }) => void;
+}
+
+export const UserEditModal: React.FC<UserEditModalProps> = ({ user, onClose, onSave }) => {
+  const [formData, setFormData] = useState({
+    first_name: user.first_name || '',
+    last_name: user.last_name || '',
+    role: user.role,
+    organization_id: user.organization_id
+  });
+  const [organizations, setOrganizations] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    loadOrganizations();
+  }, []);
+
+  const loadOrganizations = async () => {
+    try {
+      const response = await fetch('/api/admin/organizations');
+      if (response.ok) {
+        const data = await response.json();
+        setOrganizations(data);
+      }
+    } catch (error) {
+      console.error('Failed to load organizations:', error);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await onSave(formData);
+    } catch (error) {
+      console.error('Update failed:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const roles = [
+    { value: 'super_admin', label: 'Super Admin' },
+    { value: 'org_admin', label: 'Organization Admin' },
+    { value: 'aso_manager', label: 'ASO Manager' },
+    { value: 'analyst', label: 'Analyst' },
+    { value: 'viewer', label: 'Viewer' },
+    { value: 'client', label: 'Client' }
+  ];
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-gray-800 rounded-lg p-6 w-full max-w-md mx-4">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-white flex items-center">
+            <Edit3 className="w-5 h-5 mr-2 text-blue-400" />
+            Edit User
+          </h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-white">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">First Name</label>
+              <input
+                type="text"
+                value={formData.first_name}
+                onChange={(e) => setFormData({ ...formData, first_name: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Last Name</label>
+              <input
+                type="text"
+                value={formData.last_name}
+                onChange={(e) => setFormData({ ...formData, last_name: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">Organization</label>
+            <select
+              value={formData.organization_id}
+              onChange={(e) => setFormData({ ...formData, organization_id: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {organizations.map((org: any) => (
+                <option key={org.id} value={org.id}>{org.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">Role</label>
+            <select
+              value={formData.role}
+              onChange={(e) => setFormData({ ...formData, role: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {roles.map((role) => (
+                <option key={role.value} value={role.value}>{role.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex space-x-3 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-2 border border-gray-600 rounded-md text-gray-300 hover:bg-gray-700 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {loading ? 'Saving...' : 'Save Changes'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/users/UserInvitationModal.tsx
+++ b/src/components/admin/users/UserInvitationModal.tsx
@@ -1,0 +1,184 @@
+import React, { useState, useEffect } from 'react';
+import { X, UserPlus } from 'lucide-react';
+import { Building2 } from 'lucide-react';
+
+interface UserInvitationModalProps {
+  onClose: () => void;
+  onInvite: (userData: {
+    email: string;
+    role: string;
+    organization_id: string;
+    first_name?: string;
+    last_name?: string;
+  }) => void;
+}
+
+export const UserInvitationModal: React.FC<UserInvitationModalProps> = ({
+  onClose,
+  onInvite
+}) => {
+  const [formData, setFormData] = useState({
+    email: '',
+    first_name: '',
+    last_name: '',
+    role: 'viewer',
+    organization_id: ''
+  });
+  const [organizations, setOrganizations] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    loadOrganizations();
+  }, []);
+
+  const loadOrganizations = async () => {
+    try {
+      const response = await fetch('/api/admin/organizations');
+      if (response.ok) {
+        const data = await response.json();
+        setOrganizations(data);
+      }
+    } catch (error) {
+      console.error('Failed to load organizations:', error);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+
+    try {
+      await onInvite(formData);
+    } catch (error) {
+      console.error('Invitation failed:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const roles = [
+    { value: 'super_admin', label: 'Super Admin', description: 'Full platform access' },
+    { value: 'org_admin', label: 'Organization Admin', description: 'Full organization access' },
+    { value: 'aso_manager', label: 'ASO Manager', description: 'ASO data and insights access' },
+    { value: 'analyst', label: 'Analyst', description: 'Read-only data access' },
+    { value: 'viewer', label: 'Viewer', description: 'Basic dashboard access' },
+    { value: 'client', label: 'Client', description: 'Limited client portal access' }
+  ];
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-gray-800 rounded-lg p-6 w-full max-w-md mx-4">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-white flex items-center">
+            <UserPlus className="w-5 h-5 mr-2 text-orange-400" />
+            Invite User
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-white"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">
+                First Name
+              </label>
+              <input
+                type="text"
+                value={formData.first_name}
+                onChange={(e) => setFormData({ ...formData, first_name: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">
+                Last Name
+              </label>
+              <input
+                type="text"
+                value={formData.last_name}
+                onChange={(e) => setFormData({ ...formData, last_name: e.target.value })}
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Email Address *
+            </label>
+            <input
+              type="email"
+              required
+              value={formData.email}
+              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+              placeholder="user@example.com"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Organization *
+            </label>
+            <select
+              required
+              value={formData.organization_id}
+              onChange={(e) => setFormData({ ...formData, organization_id: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+            >
+              <option value="">Select Organization</option>
+              {organizations.map((org: any) => (
+                <option key={org.id} value={org.id}>
+                  {org.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Role *
+            </label>
+            <select
+              required
+              value={formData.role}
+              onChange={(e) => setFormData({ ...formData, role: e.target.value })}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+            >
+              {roles.map((role) => (
+                <option key={role.value} value={role.value}>
+                  {role.label}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-gray-400 mt-1">
+              {roles.find(r => r.value === formData.role)?.description}
+            </p>
+          </div>
+
+          <div className="flex space-x-3 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-2 border border-gray-600 rounded-md text-gray-300 hover:bg-gray-700 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex-1 px-4 py-2 bg-orange-600 text-white rounded-md hover:bg-orange-700 disabled:opacity-50 transition-colors"
+            >
+              {loading ? 'Sending...' : 'Send Invitation'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/users/UserManagementInterface.tsx
+++ b/src/components/admin/users/UserManagementInterface.tsx
@@ -1,10 +1,308 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { AdminDataTable } from '../shared/AdminDataTable';
+import { UserInvitationModal } from './UserInvitationModal';
+import { UserEditModal } from './UserEditModal';
+import { Users, UserPlus, Edit3, Trash2, RotateCcw } from 'lucide-react';
+
+interface User {
+  id: string;
+  email: string;
+  first_name?: string;
+  last_name?: string;
+  role: string;
+  organization_id: string;
+  organizations?: {
+    id: string;
+    name: string;
+    slug: string;
+  };
+  email_confirmed: boolean;
+  last_sign_in?: string;
+  created_at: string;
+}
 
 export const UserManagementInterface: React.FC = () => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showInviteModal, setShowInviteModal] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+  const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const loadUsers = async () => {
+    try {
+      setLoading(true);
+      const response = await fetch('/api/admin/users');
+      if (!response.ok) throw new Error('Failed to load users');
+      const data = await response.json();
+      setUsers(data);
+    } catch (error) {
+      console.error('Failed to load users:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleInviteUser = async (userData: {
+    email: string;
+    role: string;
+    organization_id: string;
+    first_name?: string;
+    last_name?: string;
+  }) => {
+    try {
+      const response = await fetch('/api/admin/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(userData)
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to invite user');
+      }
+
+      await response.json();
+      setShowInviteModal(false);
+      loadUsers();
+      alert(`Invitation sent successfully to ${userData.email}`);
+    } catch (error: any) {
+      console.error('Failed to invite user:', error);
+      alert(`Failed to invite user: ${error.message}`);
+    }
+  };
+
+  const handleEditUser = async (userId: string, updates: Partial<User>) => {
+    try {
+      const response = await fetch(`/api/admin/users/${userId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates)
+      });
+
+      if (!response.ok) throw new Error('Failed to update user');
+
+      setShowEditModal(false);
+      setSelectedUser(null);
+      loadUsers();
+    } catch (error) {
+      console.error('Failed to update user:', error);
+      alert('Failed to update user');
+    }
+  };
+
+  const handleDeleteUser = async (userId: string) => {
+    if (!confirm('Are you sure you want to delete this user? This action cannot be undone.')) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/admin/users/${userId}`, {
+        method: 'DELETE'
+      });
+
+      if (!response.ok) throw new Error('Failed to delete user');
+
+      loadUsers();
+    } catch (error) {
+      console.error('Failed to delete user:', error);
+      alert('Failed to delete user');
+    }
+  };
+
+  const handleResetPassword = async (userId: string) => {
+    if (!confirm('Send password reset email to this user?')) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/admin/users/${userId}/reset-password`, {
+        method: 'POST'
+      });
+
+      if (!response.ok) throw new Error('Failed to send password reset');
+
+      const result = await response.json();
+      alert(`Password reset email sent to ${result.email}`);
+    } catch (error) {
+      console.error('Failed to send password reset:', error);
+      alert('Failed to send password reset email');
+    }
+  };
+
+  const columns = [
+    {
+      header: 'User',
+      accessor: 'email',
+      cell: (user: User) => (
+        <div className="flex items-center space-x-3">
+          <div className="flex-shrink-0 h-10 w-10">
+            <div className="h-10 w-10 rounded-full bg-orange-500 flex items-center justify-center">
+              <span className="text-white font-medium text-sm">
+                {(user.first_name || user.email).charAt(0).toUpperCase()}
+              </span>
+            </div>
+          </div>
+          <div>
+            <div className="text-sm font-medium text-white">
+              {user.first_name && user.last_name
+                ? `${user.first_name} ${user.last_name}`
+                : user.email}
+            </div>
+            <div className="text-sm text-gray-400">{user.email}</div>
+          </div>
+        </div>
+      )
+    },
+    {
+      header: 'Organization',
+      accessor: 'organization',
+      cell: (user: User) => (
+        <div>
+          <div className="text-sm text-white">
+            {user.organizations?.name || 'Unknown'}
+          </div>
+          <div className="text-sm text-gray-400">
+            {user.organizations?.slug || user.organization_id}
+          </div>
+        </div>
+      )
+    },
+    {
+      header: 'Role',
+      accessor: 'role',
+      cell: (user: User) => (
+        <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+          user.role === 'super_admin'
+            ? 'bg-red-100 text-red-800'
+            : user.role === 'org_admin'
+            ? 'bg-purple-100 text-purple-800'
+            : user.role === 'aso_manager'
+            ? 'bg-blue-100 text-blue-800'
+            : 'bg-gray-100 text-gray-800'
+        }`}>
+          {user.role.replace('_', ' ')}
+        </span>
+      )
+    },
+    {
+      header: 'Status',
+      accessor: 'status',
+      cell: (user: User) => (
+        <div>
+          <div className={`text-sm ${user.email_confirmed ? 'text-green-400' : 'text-yellow-400'}`}>
+            {user.email_confirmed ? 'Confirmed' : 'Pending'}
+          </div>
+          <div className="text-xs text-gray-400">
+            {user.last_sign_in
+              ? `Last: ${new Date(user.last_sign_in).toLocaleDateString()}`
+              : 'Never logged in'}
+          </div>
+        </div>
+      )
+    },
+    {
+      header: 'Actions',
+      accessor: 'actions',
+      cell: (user: User) => (
+        <div className="flex space-x-2">
+          <button
+            onClick={() => {
+              setSelectedUser(user);
+              setShowEditModal(true);
+            }}
+            className="text-blue-400 hover:text-blue-300 p-1"
+            title="Edit User"
+          >
+            <Edit3 className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => handleResetPassword(user.id)}
+            className="text-orange-400 hover:text-orange-300 p-1"
+            title="Reset Password"
+          >
+            <RotateCcw className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => handleDeleteUser(user.id)}
+            className="text-red-400 hover:text-red-300 p-1"
+            title="Delete User"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      )
+    }
+  ];
+
   return (
-    <div className="p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
-      <h2 className="text-lg font-semibold mb-4">User Management</h2>
-      <p className="text-sm">Placeholder for user management tools.</p>
+    <div className="user-management">
+      <div className="sm:flex sm:items-center mb-6">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-white flex items-center">
+            <Users className="w-6 h-6 mr-2 text-orange-400" />
+            User Management
+          </h1>
+          <p className="mt-2 text-sm text-gray-400">
+            Manage platform users across all organizations
+          </p>
+        </div>
+        <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+          <button
+            onClick={() => setShowInviteModal(true)}
+            className="inline-flex items-center justify-center rounded-md border border-transparent bg-orange-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 transition-colors"
+          >
+            <UserPlus className="w-4 h-4 mr-2" />
+            Invite User
+          </button>
+        </div>
+      </div>
+
+      <AdminDataTable
+        data={users}
+        columns={columns}
+        loading={loading}
+        selectedItems={selectedUsers}
+        onSelectionChange={setSelectedUsers}
+        searchable={true}
+        pagination={true}
+        bulkActions={[
+          {
+            label: 'Send Password Reset',
+            action: (selected) => {
+              selected.forEach(id => handleResetPassword(id));
+            }
+          },
+          {
+            label: 'Export Users',
+            action: (selected) => {
+              console.log('Export users:', selected);
+            }
+          }
+        ]}
+      />
+
+      {showInviteModal && (
+        <UserInvitationModal
+          onClose={() => setShowInviteModal(false)}
+          onInvite={handleInviteUser}
+        />
+      )}
+
+      {showEditModal && selectedUser && (
+        <UserEditModal
+          user={selectedUser}
+          onClose={() => {
+            setShowEditModal(false);
+            setSelectedUser(null);
+          }}
+          onSave={(updates) => handleEditUser(selectedUser.id, updates)}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/api/admin/dashboard-metrics.ts
+++ b/src/pages/api/admin/dashboard-metrics.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 // @ts-nocheck
+import { NextApiRequest, NextApiResponse } from 'next';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import type { NextApiRequest, NextApiResponse } from 'next';
 import { cookies } from 'next/headers';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -11,10 +11,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const supabase = createRouteHandlerClient({ cookies });
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
+
+    // Verify super admin access
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
     if (authError || !user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
@@ -29,50 +28,147 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(403).json({ error: 'Forbidden' });
     }
 
-    const [organizationsData, usersData, bigqueryData, securityData] = await Promise.all([
+    // REAL DATA QUERIES - Replace all mocked data
+    const [
+      organizationsData,
+      usersData,
+      appsData,
+      clientAccessData,
+      auditLogsData,
+      partnershipsData
+    ] = await Promise.all([
+      // Organizations metrics
       supabase.from('organizations').select('id, subscription_tier, created_at'),
+      
+      // Users metrics  
       supabase.from('profiles').select('id, role, last_login, created_at'),
-      Promise.resolve({ data: { total_approved: 2, query_count_today: 45, data_volume_gb: 12.5 } }),
-      Promise.resolve({ data: { failed_login_attempts_24h: 3, suspicious_activities: 0, compliance_score: 98 } }),
+      
+      // REAL APPS DATA from organization_apps table
+      supabase.from('organization_apps').select(`
+        id, 
+        organization_id, 
+        app_identifier, 
+        app_name, 
+        data_source, 
+        approval_status,
+        created_at
+      `),
+      
+      // BigQuery client access
+      supabase.from('organization_client_access').select('*'),
+      
+      // Audit logs for security metrics
+      supabase.from('audit_logs').select('*').gte('created_at', new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()),
+      
+      // Partnership data (handle if table doesn't exist)
+      supabase.from('organization_partnerships').select('*').then(
+        result => result,
+        () => ({ data: [], error: null })
+      )
     ]);
+
+    // Calculate real metrics
+    const now = new Date();
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    // Organization metrics
+    const totalOrgs = organizationsData.data?.length || 0;
+    const activeOrgs = organizationsData.data?.filter(org => 
+      new Date(org.created_at) > thirtyDaysAgo
+    ).length || 0;
+    const enterpriseOrgs = organizationsData.data?.filter(org => 
+      org.subscription_tier === 'enterprise'
+    ).length || 0;
+
+    // User metrics
+    const totalUsers = usersData.data?.length || 0;
+    const activeUsers = usersData.data?.filter(user => 
+      user.last_login && new Date(user.last_login) > thirtyDaysAgo
+    ).length || 0;
+    const newUsers = usersData.data?.filter(user => 
+      new Date(user.created_at) > thirtyDaysAgo
+    ).length || 0;
+    const usersByRole = usersData.data?.reduce((acc, user) => {
+      acc[user.role] = (acc[user.role] || 0) + 1;
+      return acc;
+    }, {} as Record<string, number>) || {};
+
+    // REAL APPS METRICS - Fix the 0 apps issue
+    const totalApps = appsData.data?.length || 0;
+    const approvedApps = appsData.data?.filter(app => 
+      app.approval_status === 'approved'
+    ).length || 0;
+    const bigqueryApps = appsData.data?.filter(app => 
+      app.data_source === 'bigquery'
+    ).length || 0;
+
+    // BigQuery client metrics
+    const totalBigQueryClients = clientAccessData.data?.length || 0;
+    const orgsWithBigQueryAccess = new Set(
+      clientAccessData.data?.map(access => access.organization_id) || []
+    ).size;
+
+    // Security metrics from audit logs
+    const failedLogins = auditLogsData.data?.filter(log => 
+      log.action === 'LOGIN_FAILED'
+    ).length || 0;
+    const suspiciousActivities = auditLogsData.data?.filter(log => 
+      log.action.includes('SUSPICIOUS') || log.action.includes('VIOLATION')
+    ).length || 0;
+    const auditEntriesCount = auditLogsData.data?.length || 0;
+
+    // Partnership metrics
+    const activePartnerships = partnershipsData.data?.filter(p => 
+      p.partnership_status === 'active'
+    ).length || 0;
+
+    // Calculate system health based on real metrics
+    const getSystemHealth = () => {
+      if (failedLogins > 10 || suspiciousActivities > 0) return 'warning';
+      if (totalOrgs > 0 && totalUsers > 0 && totalApps > 0) return 'good';
+      return 'critical';
+    };
 
     const metrics = {
       platform_health: {
-        status: 'good' as const,
-        uptime_percentage: 99.9,
+        status: getSystemHealth(),
+        uptime_percentage: 99.9, // TODO: Implement real uptime monitoring
         response_time_avg: 250,
-        error_rate: 0.1,
+        error_rate: 0.1
       },
       organizations: {
-        total: organizationsData.data?.length || 0,
-        active:
-          organizationsData.data?.filter(
-            (org) => new Date(org.created_at) > new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
-          ).length || 0,
-        enterprise_tier:
-          organizationsData.data?.filter((org) => org.subscription_tier === 'enterprise').length || 0,
-        pending_invitations: 0,
-        partnerships_active: 0,
+        total: totalOrgs,
+        active: activeOrgs,
+        enterprise_tier: enterpriseOrgs,
+        pending_invitations: 0, // TODO: Track invitations
+        partnerships_active: activePartnerships
       },
       users: {
-        total_users: usersData.data?.length || 0,
-        active_last_30_days:
-          usersData.data?.filter(
-            (user) => user.last_login && new Date(user.last_login) > new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
-          ).length || 0,
-        new_this_month:
-          usersData.data?.filter(
-            (user) => new Date(user.created_at) > new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
-          ).length || 0,
-        pending_invitations: 0,
-        by_role:
-          usersData.data?.reduce((acc, user) => {
-            acc[user.role] = (acc[user.role] || 0) + 1;
-            return acc;
-          }, {}) || {},
+        total_users: totalUsers,
+        active_last_30_days: activeUsers,
+        new_this_month: newUsers,
+        pending_invitations: 0, // TODO: Track pending invitations
+        by_role: usersByRole
       },
-      bigquery_clients: bigqueryData.data,
-      security: securityData.data,
+      apps: {
+        total_apps: totalApps,
+        approved_apps: approvedApps,
+        bigquery_apps: bigqueryApps,
+        pending_approvals: totalApps - approvedApps
+      },
+      bigquery_clients: {
+        total_approved: totalBigQueryClients,
+        organizations_with_access: orgsWithBigQueryAccess,
+        data_volume_gb: 0, // TODO: Implement from BigQuery usage API
+        query_count_today: 0 // TODO: Track BigQuery usage
+      },
+      security: {
+        failed_login_attempts_24h: failedLogins,
+        suspicious_activities: suspiciousActivities,
+        audit_log_entries_today: auditEntriesCount,
+        compliance_score: suspiciousActivities === 0 ? 100 : Math.max(0, 100 - (suspiciousActivities * 10))
+      }
     };
 
     res.status(200).json(metrics);

--- a/src/pages/api/admin/organizations/[id].ts
+++ b/src/pages/api/admin/organizations/[id].ts
@@ -1,0 +1,120 @@
+/* eslint-disable */
+// @ts-nocheck
+import { NextApiRequest, NextApiResponse } from 'next';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const supabase = createRouteHandlerClient({ cookies });
+
+  // Verify super admin access
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (profile?.role !== 'super_admin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  try {
+    if (req.method === 'PUT') {
+      // UPDATE organization
+      const { name, slug, domain, subscription_tier, settings } = req.body;
+
+      const { data: updatedOrg, error } = await supabase
+        .from('organizations')
+        .update({
+          name,
+          slug,
+          domain,
+          subscription_tier,
+          settings,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', id)
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      // Log the update
+      await supabase
+        .from('audit_logs')
+        .insert({
+          organization_id: id as string,
+          user_id: user.id,
+          action: 'ORGANIZATION_UPDATED',
+          resource_type: 'organization',
+          resource_id: id as string,
+          details: {
+            changes: { name, slug, domain, subscription_tier, settings },
+            updated_by: user.email
+          }
+        });
+
+      res.status(200).json(updatedOrg);
+
+    } else if (req.method === 'DELETE') {
+      // DELETE organization (with safeguards)
+      const { data: orgToDelete } = await supabase
+        .from('organizations')
+        .select('name, slug')
+        .eq('id', id)
+        .single();
+
+      // Check if organization has users
+      const { count: userCount } = await supabase
+        .from('profiles')
+        .select('*', { count: 'exact', head: true })
+        .eq('organization_id', id);
+
+      if (userCount && userCount > 0) {
+        return res.status(400).json({
+          error: 'Cannot delete organization with existing users. Transfer or remove users first.',
+          user_count: userCount
+        });
+      }
+
+      // Delete organization (cascades will handle related records)
+      const { error: deleteError } = await supabase
+        .from('organizations')
+        .delete()
+        .eq('id', id);
+
+      if (deleteError) throw deleteError;
+
+      // Log the deletion
+      await supabase
+        .from('audit_logs')
+        .insert({
+          organization_id: null, // Organization no longer exists
+          user_id: user.id,
+          action: 'ORGANIZATION_DELETED',
+          resource_type: 'organization',
+          resource_id: id as string,
+          details: {
+            deleted_organization_name: orgToDelete?.name,
+            deleted_organization_slug: orgToDelete?.slug,
+            deleted_by: user.email
+          }
+        });
+
+      res.status(200).json({ message: 'Organization deleted successfully' });
+
+    } else {
+      res.status(405).json({ error: 'Method not allowed' });
+    }
+
+  } catch (error) {
+    console.error('Organization management error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/src/pages/api/admin/organizations/index.ts
+++ b/src/pages/api/admin/organizations/index.ts
@@ -1,0 +1,147 @@
+/* eslint-disable */
+// @ts-nocheck
+import { NextApiRequest, NextApiResponse } from 'next';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const supabase = createRouteHandlerClient({ cookies });
+
+  // Verify super admin access
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (profile?.role !== 'super_admin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  try {
+    if (req.method === 'GET') {
+      // GET all organizations with user counts
+      const { data: organizations, error } = await supabase
+        .from('organizations')
+        .select(`
+          id,
+          name,
+          slug,
+          domain,
+          subscription_tier,
+          app_limit,
+          app_limit_enforced,
+          settings,
+          created_at,
+          updated_at
+        `)
+        .order('created_at', { ascending: false });
+
+      if (error) throw error;
+
+      // Get user counts for each organization
+      const orgsWithCounts = await Promise.all(
+        organizations.map(async (org) => {
+          const { count: userCount } = await supabase
+            .from('profiles')
+            .select('*', { count: 'exact', head: true })
+            .eq('organization_id', org.id);
+
+          const { count: activeUserCount } = await supabase
+            .from('profiles')
+            .select('*', { count: 'exact', head: true })
+            .eq('organization_id', org.id)
+            .gte('last_login', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString());
+
+          const { count: appCount } = await supabase
+            .from('organization_apps')
+            .select('*', { count: 'exact', head: true })
+            .eq('organization_id', org.id)
+            .eq('approval_status', 'approved');
+
+          return {
+            ...org,
+            user_count: userCount || 0,
+            active_users_30d: activeUserCount || 0,
+            app_count: appCount || 0,
+            last_activity: new Date().toISOString() // TODO: Calculate from actual activity
+          };
+        })
+      );
+
+      res.status(200).json(orgsWithCounts);
+
+    } else if (req.method === 'POST') {
+      // CREATE new organization
+      const { name, slug, domain, subscription_tier = 'professional', settings = {} } = req.body;
+
+      // Validate required fields
+      if (!name || !slug) {
+        return res.status(400).json({
+          error: 'Missing required fields: name, slug'
+        });
+      }
+
+      // Check if slug already exists
+      const { data: existingOrg } = await supabase
+        .from('organizations')
+        .select('id')
+        .eq('slug', slug)
+        .single();
+
+      if (existingOrg) {
+        return res.status(400).json({ error: 'Organization slug already exists' });
+      }
+
+      // Create organization
+      const { data: newOrg, error: orgError } = await supabase
+        .from('organizations')
+        .insert({
+          name,
+          slug,
+          domain,
+          subscription_tier,
+          settings,
+          app_limit: subscription_tier === 'enterprise' ? 1000 : subscription_tier === 'professional' ? 50 : 10,
+          app_limit_enforced: subscription_tier !== 'enterprise'
+        })
+        .select()
+        .single();
+
+      if (orgError) throw orgError;
+
+      // Log the creation
+      await supabase
+        .from('audit_logs')
+        .insert({
+          organization_id: newOrg.id,
+          user_id: user.id,
+          action: 'ORGANIZATION_CREATED',
+          resource_type: 'organization',
+          resource_id: newOrg.id,
+          details: {
+            organization_name: name,
+            subscription_tier,
+            created_by: user.email
+          }
+        });
+
+      res.status(201).json({
+        organization: newOrg,
+        message: 'Organization created successfully'
+      });
+
+    } else {
+      res.status(405).json({ error: 'Method not allowed' });
+    }
+
+  } catch (error) {
+    console.error('Organization management error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/src/pages/api/admin/users/[id].ts
+++ b/src/pages/api/admin/users/[id].ts
@@ -1,0 +1,101 @@
+/* eslint-disable */
+// @ts-nocheck
+import { NextApiRequest, NextApiResponse } from 'next';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const supabase = createRouteHandlerClient({ cookies });
+
+  // Verify super admin access
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role, organization_id')
+    .eq('id', user.id)
+    .single();
+
+  if (profile?.role !== 'super_admin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  try {
+    if (req.method === 'PUT') {
+      // UPDATE user
+      const { role, organization_id, first_name, last_name } = req.body;
+
+      const { data: updatedUser, error } = await supabase
+        .from('profiles')
+        .update({
+          role,
+          organization_id,
+          first_name,
+          last_name,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', id)
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      // Log the change
+      await supabase
+        .from('audit_logs')
+        .insert({
+          organization_id: updatedUser.organization_id,
+          user_id: user.id,
+          action: 'USER_UPDATED',
+          resource_type: 'user',
+          resource_id: id as string,
+          details: {
+            changes: { role, organization_id, first_name, last_name },
+            updated_by: user.email
+          }
+        });
+
+      res.status(200).json(updatedUser);
+
+    } else if (req.method === 'DELETE') {
+      // DELETE user
+      const { data: userToDelete } = await supabase
+        .from('profiles')
+        .select('email, organization_id')
+        .eq('id', id)
+        .single();
+
+      // Delete from auth.users (cascades to profiles via trigger)
+      const { error: authDeleteError } = await supabase.auth.admin.deleteUser(id as string);
+      if (authDeleteError) throw authDeleteError;
+
+      // Log the deletion
+      await supabase
+        .from('audit_logs')
+        .insert({
+          organization_id: userToDelete?.organization_id,
+          user_id: user.id,
+          action: 'USER_DELETED',
+          resource_type: 'user',
+          resource_id: id as string,
+          details: {
+            deleted_user_email: userToDelete?.email,
+            deleted_by: user.email
+          }
+        });
+
+      res.status(200).json({ message: 'User deleted successfully' });
+
+    } else {
+      res.status(405).json({ error: 'Method not allowed' });
+    }
+
+  } catch (error) {
+    console.error('User management error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/src/pages/api/admin/users/[id]/reset-password.ts
+++ b/src/pages/api/admin/users/[id]/reset-password.ts
@@ -1,0 +1,77 @@
+/* eslint-disable */
+// @ts-nocheck
+import { NextApiRequest, NextApiResponse } from 'next';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { id } = req.query;
+  const supabase = createRouteHandlerClient({ cookies });
+
+  // Verify super admin access
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (profile?.role !== 'super_admin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  try {
+    // Get user email
+    const { data: targetUser } = await supabase
+      .from('profiles')
+      .select('email, organization_id')
+      .eq('id', id)
+      .single();
+
+    if (!targetUser) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    // Send password reset email via Supabase Auth
+    const { error: resetError } = await supabase.auth.resetPasswordForEmail(targetUser.email, {
+      redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/reset-password`
+    });
+
+    if (resetError) {
+      console.error('Password reset error:', resetError);
+      return res.status(500).json({ error: 'Failed to send password reset email' });
+    }
+
+    // Log the password reset request
+    await supabase
+      .from('audit_logs')
+      .insert({
+        organization_id: targetUser.organization_id,
+        user_id: user.id,
+        action: 'PASSWORD_RESET_REQUESTED',
+        resource_type: 'user',
+        resource_id: id as string,
+        details: {
+          target_user_email: targetUser.email,
+          requested_by: user.email
+        }
+      });
+
+    res.status(200).json({ 
+      message: 'Password reset email sent successfully',
+      email: targetUser.email 
+    });
+
+  } catch (error) {
+    console.error('Password reset error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/src/pages/api/admin/users/index.ts
+++ b/src/pages/api/admin/users/index.ts
@@ -1,0 +1,162 @@
+/* eslint-disable */
+// @ts-nocheck
+import { NextApiRequest, NextApiResponse } from 'next';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const supabase = createRouteHandlerClient({ cookies });
+
+  // Verify super admin access
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (profile?.role !== 'super_admin') {
+    return res.status(403).json({ error: 'Forbidden - Super admin required' });
+  }
+
+  try {
+    if (req.method === 'GET') {
+      // GET all users across all organizations
+      const { data: users, error } = await supabase
+        .from('profiles')
+        .select(`
+          id,
+          email,
+          first_name,
+          last_name,
+          role,
+          organization_id,
+          last_login,
+          created_at,
+          organizations:organization_id (
+            id,
+            name,
+            slug
+          )
+        `)
+        .order('created_at', { ascending: false });
+
+      if (error) throw error;
+
+      // Get auth.users data for email confirmation status
+      const { data: authUsers, error: authError } = await supabase.auth.admin.listUsers();
+      if (authError) throw authError;
+
+      // Merge profile and auth data
+      const enrichedUsers = users?.map(user => {
+        const authUser = authUsers.users.find(au => au.id === user.id);
+        return {
+          ...user,
+          email_confirmed: authUser?.email_confirmed_at ? true : false,
+          last_sign_in: authUser?.last_sign_in_at,
+          auth_provider: authUser?.app_metadata?.provider || 'email'
+        };
+      });
+
+      res.status(200).json(enrichedUsers);
+
+    } else if (req.method === 'POST') {
+      // CREATE new user (invitation)
+      const { email, role, organization_id, first_name, last_name } = req.body;
+
+      // Validate required fields
+      if (!email || !role || !organization_id) {
+        return res.status(400).json({ 
+          error: 'Missing required fields: email, role, organization_id' 
+        });
+      }
+
+      // Validate role
+      const validRoles = ['super_admin', 'org_admin', 'aso_manager', 'analyst', 'viewer', 'client'];
+      if (!validRoles.includes(role)) {
+        return res.status(400).json({ error: 'Invalid role' });
+      }
+
+      // Check if user already exists
+      const { data: existingUser } = await supabase
+        .from('profiles')
+        .select('id')
+        .eq('email', email)
+        .single();
+
+      if (existingUser) {
+        return res.status(400).json({ error: 'User already exists' });
+      }
+
+      // Create user invitation via Supabase Auth Admin
+      const { data: authUser, error: inviteError } = await supabase.auth.admin.inviteUserByEmail(email, {
+        data: {
+          first_name,
+          last_name,
+          role,
+          organization_id
+        },
+        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`
+      });
+
+      if (inviteError) {
+        console.error('Invite error:', inviteError);
+        return res.status(500).json({ error: 'Failed to send invitation' });
+      }
+
+      // Create profile record
+      const { data: profile, error: profileError } = await supabase
+        .from('profiles')
+        .insert({
+          id: authUser.user.id,
+          email,
+          first_name,
+          last_name,
+          role,
+          organization_id
+        })
+        .select()
+        .single();
+
+      if (profileError) {
+        console.error('Profile creation error:', profileError);
+        // Clean up auth user if profile creation fails
+        await supabase.auth.admin.deleteUser(authUser.user.id);
+        return res.status(500).json({ error: 'Failed to create user profile' });
+      }
+
+      // Log the invitation
+      await supabase
+        .from('audit_logs')
+        .insert({
+          organization_id,
+          user_id: user.id,
+          action: 'USER_INVITED',
+          resource_type: 'user',
+          resource_id: profile.id,
+          details: {
+            invited_email: email,
+            assigned_role: role,
+            invited_by: user.email
+          }
+        });
+
+      res.status(201).json({
+        user: profile,
+        invitation_sent: true,
+        message: 'User invited successfully'
+      });
+
+    } else {
+      res.status(405).json({ error: 'Method not allowed' });
+    }
+
+  } catch (error) {
+    console.error('User management error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}


### PR DESCRIPTION
## Summary
- add Supabase-backed user management API with invite, update, delete, and password reset endpoints
- expose organization management API for listing, creation, update and removal with audit logging
- replace placeholder admin UI with user management table, invitation and edit modals, and hook dashboard metrics into real data sources

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / 616 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a4448ea03083268f48acc6c7f9cce4