### PR TITLE
Enhance organization management integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ const Profile = lazy(() => import("./pages/profile"));
 const Settings = lazy(() => import("./pages/settings"));
 const Admin = lazy(() => import("./pages/admin"));
 const AdminPlaceholder = lazy(() => import("./pages/admin/placeholder"));
+const AdminOrganizations = lazy(() => import("./pages/admin/organizations"));
 const SignIn = lazy(() => import("./pages/auth/sign-in"));
 const SignUp = lazy(() => import("./pages/auth/sign-up"));
 const SmokeTest = lazy(() => import("./pages/smoke-test"));
@@ -146,6 +147,10 @@ function App() {
                           <Route
                             path="/admin/placeholder"
                             element={<ProtectedRoute><AdminPlaceholder /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/admin/organizations"
+                            element={<ProtectedRoute><AdminOrganizations /></ProtectedRoute>}
                           />
                           <Route
                             path="/smoke-test"

--- a/src/components/admin/layout/AdminSidebar.tsx
+++ b/src/components/admin/layout/AdminSidebar.tsx
@@ -113,7 +113,7 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({ collapsed, currentPa
           id: 'organizations',
           label: 'Organizations',
           icon: Building2,
-          href: '/admin?tab=organizations',
+          href: '/admin/organizations',
           status: navigationConfig['organizations'],
         },
         {

--- a/src/pages/admin/organizations.tsx
+++ b/src/pages/admin/organizations.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react';
+import { AdminLayout } from '@/components/admin/layout/AdminLayout';
+import { OrganizationManagementTable } from '@/components/admin/organizations/OrganizationManagementTable';
+import { usePermissions } from '@/hooks/usePermissions';
+import { useNavigate } from 'react-router-dom';
+
+const OrganizationsPage: React.FC = () => {
+  const { isSuperAdmin, isLoading } = usePermissions();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoading && !isSuperAdmin) {
+      navigate('/dashboard');
+    }
+  }, [isSuperAdmin, isLoading, navigate]);
+
+  if (isLoading) {
+    return <div className="admin-loading">Loading organizations...</div>;
+  }
+
+  if (!isSuperAdmin) {
+    return null;
+  }
+
+  return (
+    <AdminLayout currentPage="organizations">
+      <OrganizationManagementTable />
+    </AdminLayout>
+  );
+};
+
+export default OrganizationsPage;


### PR DESCRIPTION
## Summary
- surface organization query errors in admin dashboard metrics
- add GET handler for retrieving organization details
- build organization management UI for editing and deleting orgs
- introduce dedicated organizations admin page and navigation link
- validate organization creation with client-side feedback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 570 errors, 51 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a454a164688326841e8d7dbf6971f3