### PR TITLE
feat: enable admin organization and user management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ const Settings = lazy(() => import("./pages/settings"));
 const Admin = lazy(() => import("./pages/admin"));
 const AdminPlaceholder = lazy(() => import("./pages/admin/placeholder"));
 const AdminOrganizations = lazy(() => import("./pages/admin/organizations"));
+const AdminUsers = lazy(() => import("./pages/admin/users"));
 const SignIn = lazy(() => import("./pages/auth/sign-in"));
 const SignUp = lazy(() => import("./pages/auth/sign-up"));
 const SmokeTest = lazy(() => import("./pages/smoke-test"));
@@ -151,6 +152,10 @@ function App() {
                           <Route
                             path="/admin/organizations"
                             element={<ProtectedRoute><AdminOrganizations /></ProtectedRoute>}
+                          />
+                          <Route
+                            path="/admin/users"
+                            element={<ProtectedRoute><AdminUsers /></ProtectedRoute>}
                           />
                           <Route
                             path="/smoke-test"

--- a/src/components/admin/layout/AdminSidebar.tsx
+++ b/src/components/admin/layout/AdminSidebar.tsx
@@ -31,8 +31,8 @@ interface AdminSidebarProps {
 
 const navigationConfig: Record<string, NavigationItem['status']> = {
   dashboard: 'ready',
-  organizations: 'in_development',
-  users: 'in_development',
+  organizations: 'ready',
+  users: 'ready',
   'system-status': 'placeholder',
   roles: 'placeholder',
   invitations: 'placeholder',

--- a/src/components/admin/organizations/EditOrganizationModal.tsx
+++ b/src/components/admin/organizations/EditOrganizationModal.tsx
@@ -11,7 +11,7 @@ interface Organization {
 interface EditOrganizationModalProps {
   organization: Organization;
   onClose: () => void;
-  onSave: (updates: Partial<Organization>) => void;
+  onSave: (updates: Partial<Organization>) => Promise<void>;
 }
 
 export const EditOrganizationModal: React.FC<EditOrganizationModalProps> = ({ organization, onClose, onSave }) => {
@@ -29,20 +29,11 @@ export const EditOrganizationModal: React.FC<EditOrganizationModalProps> = ({ or
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch(`/api/admin/organizations/${organization.id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(formData),
-      });
-      if (!response.ok) {
-        const err = await response.json();
-        throw new Error(err.error || 'Failed to update organization');
-      }
-      const result = await response.json();
-      onSave(result);
-    } catch (err: any) {
-      console.error('Failed to update organization:', err);
-      setError(err.message);
+      await onSave(formData);
+    } catch (err: unknown) {
+      const error = err as Error;
+      console.error('Failed to update organization:', error);
+      setError(error.message);
     } finally {
       setLoading(false);
     }

--- a/src/components/admin/users/UserManagementInterface.tsx
+++ b/src/components/admin/users/UserManagementInterface.tsx
@@ -24,6 +24,7 @@ interface User {
 export const UserManagementInterface: React.FC = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
@@ -37,11 +38,18 @@ export const UserManagementInterface: React.FC = () => {
     try {
       setLoading(true);
       const response = await fetch('/api/admin/users');
-      if (!response.ok) throw new Error('Failed to load users');
+
+      if (!response.ok) {
+        throw new Error(`Failed to load users: ${response.status}`);
+      }
+
       const data = await response.json();
       setUsers(data);
-    } catch (error) {
+      console.log(`Loaded ${data.length} users across all organizations`);
+    } catch (err: unknown) {
+      const error = err as Error;
       console.error('Failed to load users:', error);
+      setError(error.message);
     } finally {
       setLoading(false);
     }
@@ -70,9 +78,10 @@ export const UserManagementInterface: React.FC = () => {
       setShowInviteModal(false);
       loadUsers();
       alert(`Invitation sent successfully to ${userData.email}`);
-    } catch (error: any) {
-      console.error('Failed to invite user:', error);
-      alert(`Failed to invite user: ${error.message}`);
+    } catch (error: unknown) {
+      const err = error as Error;
+      console.error('Failed to invite user:', err);
+      alert(`Failed to invite user: ${err.message}`);
     }
   };
 
@@ -241,6 +250,7 @@ export const UserManagementInterface: React.FC = () => {
 
   return (
     <div className="user-management">
+      {error && <div className="mb-4 text-red-500">{error}</div>}
       <div className="sm:flex sm:items-center mb-6">
         <div className="sm:flex-auto">
           <h1 className="text-2xl font-semibold text-white flex items-center">

--- a/src/pages/admin/users.tsx
+++ b/src/pages/admin/users.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
 import { AdminLayout } from '@/components/admin/layout/AdminLayout';
-import { OrganizationManagementTable } from '@/components/admin/organizations/OrganizationManagementTable';
+import { UserManagementInterface } from '@/components/admin/users/UserManagementInterface';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useNavigate } from 'react-router-dom';
 
-const OrganizationsPage: React.FC = () => {
+const UsersPage: React.FC = () => {
   const { isSuperAdmin, isLoading } = usePermissions();
   const navigate = useNavigate();
 
@@ -17,7 +17,7 @@ const OrganizationsPage: React.FC = () => {
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="text-lg text-white">Loading organizations...</div>
+        <div className="text-lg text-white">Loading users...</div>
       </div>
     );
   }
@@ -27,10 +27,10 @@ const OrganizationsPage: React.FC = () => {
   }
 
   return (
-    <AdminLayout currentPage="organizations">
-      <OrganizationManagementTable />
+    <AdminLayout currentPage="users">
+      <UserManagementInterface />
     </AdminLayout>
   );
 };
 
-export default OrganizationsPage;
+export default UsersPage;


### PR DESCRIPTION
## Summary
- add dedicated admin pages for organizations and users with permission checks
- wire organization management UI to live APIs with create, edit and delete actions
- surface user management data from backend and display API errors
- activate navigation entries for organizations and users

## Testing
- `npm run lint` *(fails: Unexpected any types)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4756021f083268aba73443d724fb4