### PR TITLE
feat: add competitor analysis workflow

### DIFF
--- a/src/components/AsoAiHub/CreativeAnalysis/CompetitorCard.tsx
+++ b/src/components/AsoAiHub/CreativeAnalysis/CompetitorCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { ScrapedMetadata } from '@/types/aso';
+
+interface CompetitorCardProps {
+  app: ScrapedMetadata;
+  onRemove: (app: ScrapedMetadata) => void;
+}
+
+export const CompetitorCard = ({ app, onRemove }: CompetitorCardProps) => (
+  <div className="competitor-card flex items-center gap-4 p-4 border border-zinc-800 rounded-lg">
+    {app.icon && (
+      <img src={app.icon} alt={app.name} className="w-12 h-12 rounded-lg" />
+    )}
+    <div className="flex-1 overflow-hidden">
+      <h4 className="font-semibold truncate text-foreground">{app.name}</h4>
+      {app.developer && (
+        <p className="text-sm text-zinc-400 truncate">{app.developer}</p>
+      )}
+      <div className="text-xs text-zinc-500 flex gap-2">
+        {app.rating && <span>★ {app.rating}</span>}
+        {app.applicationCategory && <span>{app.applicationCategory}</span>}
+      </div>
+    </div>
+    <Button variant="ghost" size="sm" onClick={() => onRemove(app)}>
+      Remove
+    </Button>
+  </div>
+);
+


### PR DESCRIPTION
## Summary
- extend app selection modal with multi-select search and country-aware browsing
- add competitor tab and selection flow to Creative Analysis hub
- wire ASO search service for country-aware queries and helper search

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a71252617483269fe1599eb8da9f81