### PR TITLE
fix: use appId for app selection

### DIFF
--- a/src/components/shared/AsoShared/AppSelectionModal.tsx
+++ b/src/components/shared/AsoShared/AppSelectionModal.tsx
@@ -60,13 +60,21 @@ export const AppSelectionModal: React.FC<AppSelectionModalProps> = ({
   const buttonText = mode === 'analyze' ? 'Analyze This App' : 'Select';
   const buttonIcon = mode === 'analyze' ? <Target className="w-4 h-4 mr-2" /> : null;
 
-  const [internalSelectedApps, setInternalSelectedApps] = useState<ScrapedMetadata[]>(selectedApps);
+  const [internalSelectedApps, setInternalSelectedApps] = useState<ScrapedMetadata[]>(() => {
+    const uniqueApps = (selectedApps || []).filter(
+      (app, index, arr) => arr.findIndex((a) => a.appId === app.appId) === index
+    );
+    return uniqueApps;
+  });
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<ScrapedMetadata[]>(candidates);
   const [searching, setSearching] = useState(false);
 
   useEffect(() => {
-    setInternalSelectedApps(selectedApps);
+    const uniqueApps = (selectedApps || []).filter(
+      (app, index, arr) => arr.findIndex((a) => a.appId === app.appId) === index
+    );
+    setInternalSelectedApps(uniqueApps);
   }, [selectedApps]);
 
   useEffect(() => {
@@ -76,9 +84,9 @@ export const AppSelectionModal: React.FC<AppSelectionModalProps> = ({
   }, [candidates, selectMode]);
 
   const handleAppToggle = (app: ScrapedMetadata) => {
-    const isSelected = internalSelectedApps.some((a) => a.bundleId === app.bundleId);
+    const isSelected = internalSelectedApps.some((a) => a.appId === app.appId);
     if (isSelected) {
-      setInternalSelectedApps((prev) => prev.filter((a) => a.bundleId !== app.bundleId));
+      setInternalSelectedApps((prev) => prev.filter((a) => a.appId !== app.appId));
     } else if (internalSelectedApps.length < maxSelections) {
       setInternalSelectedApps((prev) => [...prev, app]);
     }
@@ -99,7 +107,7 @@ export const AppSelectionModal: React.FC<AppSelectionModalProps> = ({
         variant: 'default',
       };
     }
-    const isSelected = internalSelectedApps.some((a) => a.bundleId === app.bundleId);
+    const isSelected = internalSelectedApps.some((a) => a.appId === app.appId);
     const isAtLimit = internalSelectedApps.length >= maxSelections;
     return {
       text: isSelected ? 'Remove' : 'Add to Compare',


### PR DESCRIPTION
## Summary
- ensure AppSelectionModal uses `appId` to track selected apps
- de-duplicate initial selected apps by `appId`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any... 615 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a7250df2d08326be2c820ade7b2a2f