### PR TITLE
feat: support platform super admin without organization

### DIFF
--- a/src/components/AiInsightsPanel.tsx
+++ b/src/components/AiInsightsPanel.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { ManualInsightsPanel } from './AiInsightsPanel/ManualInsightsPanel';
 import { useUserProfile } from '@/hooks/useUserProfile';
+import { useSuperAdmin } from '@/context/SuperAdminContext';
 import type { MetricsData } from '@/types/aso';
 
 interface AiInsightsPanelProps {
@@ -14,15 +15,17 @@ export const AiInsightsPanel: React.FC<AiInsightsPanelProps> = ({
   metricsData
 }) => {
   const { profile } = useUserProfile();
+  const { isSuperAdmin, selectedOrganizationId } = useSuperAdmin();
 
-  if (!profile?.organization_id) {
+  const organizationId = isSuperAdmin ? selectedOrganizationId : profile?.organization_id;
+  if (!organizationId) {
     return null;
   }
 
   return (
     <ManualInsightsPanel
       className={className}
-      organizationId={profile.organization_id}
+      organizationId={organizationId}
       metricsData={metricsData}
     />
   );

--- a/src/components/Auth/ProtectedRoute.tsx
+++ b/src/components/Auth/ProtectedRoute.tsx
@@ -28,12 +28,12 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   // ✅ ENHANCED: Only redirect non-super-admin users without organization
   // Platform Super Admins can have null organization_id and should access dashboard
   if (profile && !profile.organization_id) {
-    // Check if user is a super admin
     const userRoles = profile.user_roles || [];
-    const isSuperAdmin = userRoles.some((role: any) => 
-      role.role === 'SUPER_ADMIN' && role.organization_id === null
-    );
-    
+    const isSuperAdmin =
+      userRoles.some(
+        (role: any) => role.role?.toLowerCase() === 'super_admin' && role.organization_id === null
+      ) || profile.role?.toLowerCase() === 'super_admin';
+
     if (!isSuperAdmin) {
       return <Navigate to="/apps" replace />;
     }

--- a/src/hooks/useComparisonData.ts
+++ b/src/hooks/useComparisonData.ts
@@ -4,6 +4,7 @@ import { useAsoData } from '../context/AsoDataContext';
 import { useBigQueryData } from './useBigQueryData';
 import { useAuth } from '@/context/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
+import { useSuperAdmin } from '@/context/SuperAdminContext';
 import { standardizeChartData } from '../utils/format';
 import { getPreviousPeriod, calculateDeltas } from '../utils/dateCalculations';
 import { AsoData } from './useMockAsoData';
@@ -31,11 +32,17 @@ export interface ComparisonData {
 export const useComparisonData = (type: ComparisonType): ComparisonData => {
   const { filters } = useAsoData();
   const { user } = useAuth();
+  const { isSuperAdmin, selectedOrganizationId } = useSuperAdmin();
   const [organizationId, setOrganizationId] = useState<string>('');
 
-  // Get organization ID from user profile
+  // Get organization ID from user profile or super admin selection
   useEffect(() => {
     const fetchOrganizationId = async () => {
+      if (isSuperAdmin) {
+        setOrganizationId(selectedOrganizationId || '');
+        return;
+      }
+
       if (!user) return;
 
       try {
@@ -59,7 +66,7 @@ export const useComparisonData = (type: ComparisonType): ComparisonData => {
     };
 
     fetchOrganizationId();
-  }, [user]);
+  }, [user, isSuperAdmin, selectedOrganizationId]);
   
   // Calculate previous period date range
   const previousDateRange = useMemo(() => {

--- a/src/lib/middleware/types.ts
+++ b/src/lib/middleware/types.ts
@@ -12,7 +12,8 @@ export interface ApiRequest {
   };
   user?: User;
   session?: Session;
-  organizationId?: string;
+  organizationId?: string | null;
+  isSuperAdmin?: boolean;
   rateLimitInfo?: {
     remaining: number;
     resetTime: Date;

--- a/src/services/security.service.ts
+++ b/src/services/security.service.ts
@@ -147,6 +147,11 @@ class SecurityService {
         return { success: false, errors: [{ field: 'user', message: 'User profile not found', code: 'USER_NOT_FOUND' }] };
       }
 
+      const isSuperAdmin = profile.role?.toLowerCase() === 'super_admin';
+      if (isSuperAdmin) {
+        return { success: true, data: true };
+      }
+
       if (profile.organization_id !== organizationId) {
         return { success: false, errors: [{ field: 'organization', message: 'Access denied to organization', code: 'ACCESS_DENIED' }] };
       }


### PR DESCRIPTION
## Summary
- handle platform-level super admins in auth middleware and permissions
- enable organization selection for super admins across app contexts
- bypass organization validation for super admins

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6f47b5fa88326949250134754f6d2