### PR TITLE
refactor: unify role checks to user_roles

### DIFF
--- a/src/components/Auth/ProtectedRoute.tsx
+++ b/src/components/Auth/ProtectedRoute.tsx
@@ -3,6 +3,7 @@ import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/context/AuthContext';
 import { AuthLoadingSpinner } from '@/components/Auth/AuthLoadingSpinner';
 import { useUserProfile } from '@/hooks/useUserProfile';
+import type { Tables } from '@/integrations/supabase/types';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -28,11 +29,10 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   // ✅ ENHANCED: Only redirect non-super-admin users without organization
   // Platform Super Admins can have null organization_id and should access dashboard
   if (profile && !profile.organization_id) {
-    const userRoles = profile.user_roles || [];
-    const isSuperAdmin =
-      userRoles.some(
-        (role: any) => role.role?.toLowerCase() === 'super_admin' && role.organization_id === null
-      ) || profile.role?.toLowerCase() === 'super_admin';
+    const userRoles = (profile.user_roles || []) as Tables<'user_roles'>[];
+    const isSuperAdmin = userRoles.some(
+      (role) => role.role?.toLowerCase() === 'super_admin' && role.organization_id === null
+    );
 
     if (!isSuperAdmin) {
       return <Navigate to="/apps" replace />;


### PR DESCRIPTION
## Summary
- rely solely on `user_roles` in permission hook and auth middleware
- compute super-admin status via `user_roles` in ProtectedRoute and security service
- remove deprecated `profile.role` usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 569 errors, 52 warnings)*
- `npx eslint src/hooks/usePermissions.ts src/components/Auth/ProtectedRoute.tsx src/services/security.service.ts src/lib/middleware/auth.middleware.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b715abdcec8326b4a394cb7b1b3414