### PR TITLE
Specify GET method when fetching admin organizations

### DIFF
--- a/src/components/admin/organizations/OrganizationManagementTable.tsx
+++ b/src/components/admin/organizations/OrganizationManagementTable.tsx
@@ -42,8 +42,10 @@ export const OrganizationManagementTable: React.FC = () => {
   const loadOrganizations = async () => {
     try {
       setLoading(true);
-      const { data: response, error } = await supabase.functions.invoke('admin-organizations');
-      
+      const { data: response, error } = await supabase.functions.invoke('admin-organizations', {
+        method: 'GET'
+      });
+
       if (error) throw error;
       if (!response?.success) throw new Error(response?.error || 'Request failed');
       

--- a/src/components/admin/users/UserEditModal.tsx
+++ b/src/components/admin/users/UserEditModal.tsx
@@ -35,7 +35,9 @@ export const UserEditModal: React.FC<UserEditModalProps> = ({ user, onClose, onS
 
   const loadOrganizations = async () => {
     try {
-      const { data: response, error } = await supabase.functions.invoke('admin-organizations');
+      const { data: response, error } = await supabase.functions.invoke('admin-organizations', {
+        method: 'GET'
+      });
       if (error) throw error;
       if (response?.success) {
         setOrganizations(response.data || []);

--- a/src/components/admin/users/UserInvitationModal.tsx
+++ b/src/components/admin/users/UserInvitationModal.tsx
@@ -34,7 +34,9 @@ export const UserInvitationModal: React.FC<UserInvitationModalProps> = ({
 
   const loadOrganizations = async () => {
     try {
-      const { data: response, error } = await supabase.functions.invoke('admin-organizations');
+      const { data: response, error } = await supabase.functions.invoke('admin-organizations', {
+        method: 'GET'
+      });
       if (error) throw error;
       if (response?.success) {
         setOrganizations(response.data || []);


### PR DESCRIPTION
## Summary
- Use `GET` method when loading organization list in admin sections
- Ensure organization lists are fetched with explicit method in user invitation and edit modals

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 569 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8201d3f64832680b8adceb8dd892c