### PR TITLE
feat: add service role key guard

### DIFF
--- a/supabase/functions/admin-users/index.ts
+++ b/supabase/functions/admin-users/index.ts
@@ -20,9 +20,13 @@ serve(async (req) => {
     )
 
     // Admin client with service key for user operations
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+    if (!serviceRoleKey) {
+      return new Response('Service role key missing', { status: 500 })
+    }
     const supabaseAdmin = createClient(
       Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+      serviceRoleKey!
     )
 
     const { data: user } = await supabase.auth.getUser()


### PR DESCRIPTION
## Summary
- ensure SUPABASE_SERVICE_ROLE_KEY is defined before initializing admin client
- return 500 when service role key is missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 622 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bc017d6bd083269a83298c5c56cfbe