### PR TITLE
fix: define body in admin users function

### DIFF
--- a/supabase/functions/admin-users/index.ts
+++ b/supabase/functions/admin-users/index.ts
@@ -73,7 +73,7 @@ serve(async (req) => {
       });
     }
 
-    const { action } = requestBody;
+    const { action, ...body } = requestBody;
     console.log('Action requested:', action);
 
     if (action === 'env_check') {
@@ -214,7 +214,7 @@ serve(async (req) => {
       console.log('Action type:', action);
       
       // Create/invite new user
-      const normalizedBody = normalizeUserFields(requestBody)
+      const normalizedBody = normalizeUserFields(body)
       console.log('Normalized body:', JSON.stringify(normalizedBody, null, 2));
       
       const { email, roles, organization_id, first_name, last_name, password } = normalizedBody


### PR DESCRIPTION
## Summary
- define `body` from parsed request payload
- normalize user fields using defined `body`

## Testing
- `npx eslint supabase/functions/admin-users/index.ts`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68bd5eb51abc832681774b83db4df726