### PR TITLE
feat: restrict theme switching to super_admin only

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,14 @@
   <body>
     <script>
       (function() {
-        const stored = localStorage.getItem('theme');
+        const isSuper = localStorage.getItem('is-super-admin') === 'true';
         const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const theme = stored === 'light' || stored === 'dark' ? stored : (systemPrefersDark ? 'dark' : 'light');
+        const stored = isSuper ? localStorage.getItem('theme') : null;
+        const theme = stored === 'light' || stored === 'dark'
+          ? stored
+          : isSuper
+            ? (systemPrefersDark ? 'dark' : 'light')
+            : 'dark';
         document.documentElement.classList.add(theme);
       })();
     </script>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -13,11 +13,13 @@ import { useUserProfile } from "@/hooks/useUserProfile";
 import { SuperAdminBadge } from "@/components/SuperAdminBadge";
 import { PermissionWrapper } from "@/components/PermissionWrapper";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { useSuperAdmin } from "@/context/SuperAdminContext";
 
 const TopBar: React.FC = React.memo(() => {
   const location = useLocation();
   const { selectedApps, setSelectedApps } = useBigQueryAppSelection();
   const { profile, isLoading: profileLoading } = useUserProfile();
+  const { isSuperAdmin } = useSuperAdmin();
   
   const getPageTitle = () => {
     switch (location.pathname) {
@@ -124,9 +126,11 @@ const TopBar: React.FC = React.memo(() => {
             </div>
           )}
           <div className="flex items-center gap-2">
-            <div className="theme-toggle-container">
-              <ThemeToggle />
-            </div>
+            {isSuperAdmin && (
+              <div className="theme-toggle-container">
+                <ThemeToggle />
+              </div>
+            )}
             <UserMenu />
           </div>
         </div>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -140,6 +140,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (error) {
         throw error;
       }
+      localStorage.setItem('is-super-admin', 'false');
       navigate('/auth/sign-in');
     } catch (error: any) {
       toast({

--- a/src/context/SuperAdminContext.tsx
+++ b/src/context/SuperAdminContext.tsx
@@ -32,6 +32,11 @@ export const SuperAdminProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     }
   }, [selectedOrganizationId, isSuperAdmin]);
 
+  // Persist super admin status for theme control
+  useEffect(() => {
+    localStorage.setItem('is-super-admin', isSuperAdmin ? 'true' : 'false');
+  }, [isSuperAdmin]);
+
   const isPlatformWideMode = isSuperAdmin && selectedOrganizationId === null;
 
   const contextValue: SuperAdminContextType = {


### PR DESCRIPTION
## Summary
- Show theme toggle only for super admins and gate theme changes behind role checks
- Force dark theme for non-admins via preload script and default handling
- Persist super admin flag for theme control and clear on sign out

## Testing
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf062a9a9883269ab23ac07f895f1d