### PR TITLE
Remove redundant sign-up link on sign-in page

### DIFF
--- a/src/pages/auth/sign-in.tsx
+++ b/src/pages/auth/sign-in.tsx
@@ -52,14 +52,6 @@ const SignIn = () => {
           </CardHeader>
           <CardContent>
             <SignInForm />
-            <div className="mt-6 text-center">
-              <p className="text-sm text-zinc-400">
-                Don't have an account?{' '}
-                <a href="/auth/sign-up" className="text-yodel-orange hover:underline">
-                  Sign up
-                </a>
-              </p>
-            </div>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- remove duplicate sign-up prompt from sign-in page, relying on SignInForm footer link

## Testing
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c076ec11308326a8f7e0b7a5974779